### PR TITLE
Reword help and descriptions, fix plugin URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <packaging>hpi</packaging>
   <version>1.9-SNAPSHOT</version>
   <url>
-    http://wiki.hudson-ci.org/display/HUDSON/Naginator+Plugin
+    https://wiki.jenkins-ci.org/display/JENKINS/Naginator+Plugin
   </url>
 
   <scm>

--- a/src/main/java/com/chikli/hudson/plugin/naginator/FixedDelay.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/FixedDelay.java
@@ -31,7 +31,7 @@ public class FixedDelay extends ScheduleDelay {
     public static class DescriptorImpl extends ScheduleDelayDescriptor {
         @Override
         public String getDisplayName() {
-            return "Fixed delay";
+            return "Fixed";
         }
     }
 }

--- a/src/main/java/com/chikli/hudson/plugin/naginator/ProgressiveDelay.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/ProgressiveDelay.java
@@ -56,7 +56,7 @@ public class ProgressiveDelay extends ScheduleDelay {
     public static class DescriptorImpl extends ScheduleDelayDescriptor {
         @Override
         public String getDisplayName() {
-            return "Progressively introduce delay until the next build";
+            return "Progressive";
         }
     }
 }

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/config.jelly
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/config.jelly
@@ -3,12 +3,12 @@
         <f:checkbox />
     </f:entry>
 
-    <f:entry title="${%Delay before schedule}">
+    <f:entry title="${%Delay before retrying build}">
         <j:invokeStatic var="delays" className="com.chikli.hudson.plugin.naginator.ScheduleDelay" method="all"/>
         <f:hetero-radio descriptors="${delays}" field="delay"/>
     </f:entry>
 
-    <f:entry title="${%Max number of successive failed build}" field="maxSchedule">
+    <f:entry title="${%Maximum number of successive failed builds}" field="maxSchedule">
         <f:textbox/>
     </f:entry>
 

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/help-delay.html
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/help-delay.html
@@ -1,0 +1,1 @@
+<div>Fixed delay in seconds before retrying build.</div>

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/help-maxSchedule.html
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/help-maxSchedule.html
@@ -1,3 +1,3 @@
 <div>
-    Limits the number of successive job schedules after a build failure. Set to 0 for no limit.
+    Limit successive failed build retries. Set to 0 for no limit.
 </div>

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/help.html
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/help.html
@@ -1,3 +1,6 @@
 <div>
-    This option allows to reschedule job upon failure.
+    This action reschedules failed builds. Note: immediate rescheduling of
+    failed builds, combined with publishers such as e-mail or IM, will flood the
+    recipients. Take care to configure a suitable delay between builds or limit
+    the maximum retries.
 </div>

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/ProgressiveDelay/config.jelly
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/ProgressiveDelay/config.jelly
@@ -2,7 +2,7 @@
   <f:entry title="Increment" field="increment">
     <f:textbox />
   </f:entry>
-  <f:entry title="Max" field="max">
+  <f:entry title="Maximum" field="max">
     <f:textbox />
   </f:entry>
 </j:jelly>

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/ProgressiveDelay/help.html
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/ProgressiveDelay/help.html
@@ -1,11 +1,6 @@
 <div xmlns="http://www.w3.org/1999/html">
-    If a build fails for a reason that cannot be immediately fixed,
-    immediate rescheduling may cause a very tight loop.
-    combined with publishers like e-mail, IM, this could flood the users.
-    <p>
-    So to avoid this problem, progressively introduce delay (in sec) until the next build.
-    The delay starts with the <em>increment</em> value,then it is grows by the
-    <tt>increment * number of consecutive failures</tt>
-    (e.g. starting with 5, it takes 10, 20, 35, 55 ...etc... up to the max value)
-    then the delay value remains the <em>max</em>.
+    Progressively delay before retrying build. The delay starts at
+    <em>increment</em> seconds and grows by <tt>increment * number of
+    consecutive failures</tt> up to the maximum value, then remains at
+    <em>maximum</em>. e.g. (5, 10, 20, 35, 55, ..., maximum) seconds.
 </div>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -4,5 +4,5 @@
   Since we don't really have anything dynamic here, let's just use static HTML. 
 -->
 <div>
-  This plugin allows you to reschedule job upon failure.
+  This plugin reschedules failed jobs.
 </div>

--- a/src/main/webapp/help-delay.html
+++ b/src/main/webapp/help-delay.html
@@ -1,1 +1,0 @@
-<div># of seconds before the next build will kick off.</div>


### PR DESCRIPTION
- Update plugin URL to point to wiki.jenkins-ci.org
- Move help-delay.html to correct directory so it will be used
- Refactor/reword the help
