### PR TITLE
Preserve Cause history.

### DIFF
--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorCause.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorCause.java
@@ -1,16 +1,16 @@
 package com.chikli.hudson.plugin.naginator;
 
-import hudson.model.Cause.UpstreamCause;
-import hudson.model.Run;
+import hudson.model.Cause;
 
 /**
  * {@link Cause} for builds triggered by this plugin.
  * @author Alan.Harder@sun.com
+ * Deprecated in favor of NaginatorUpstreamCause but leaving in place to ensure
+ * that existing installations that reference this Cause in their build history
+ * do not run into issues when displaying Causes prior to upgrade to newer
+ * versions.
  */
-public class NaginatorCause extends UpstreamCause {
-    public NaginatorCause(Run<?, ?> up) {
-        super(up);
-    }
+public class NaginatorCause extends Cause {
 
     @Override
     public String getShortDescription() {

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorCause.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorCause.java
@@ -1,12 +1,16 @@
 package com.chikli.hudson.plugin.naginator;
 
-import hudson.model.Cause;
+import hudson.model.Cause.UpstreamCause;
+import hudson.model.Run;
 
 /**
  * {@link Cause} for builds triggered by this plugin.
  * @author Alan.Harder@sun.com
  */
-public class NaginatorCause extends Cause {
+public class NaginatorCause extends UpstreamCause {
+    public NaginatorCause(Run<?, ?> up) {
+        super(up);
+    }
 
     @Override
     public String getShortDescription() {

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorListener.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorListener.java
@@ -133,7 +133,7 @@ public class NaginatorListener extends RunListener<AbstractBuild<?,?>> {
         for (Combination c : combinations) {
             nma.addCombinationToRerun(c);
         }
-        return build.getProject().scheduleBuild(n, new NaginatorCause((Run) build), p, nma, causeAction);
+        return build.getProject().scheduleBuild(n, new NaginatorUpstreamCause((Run) build), p, nma, causeAction);
     }
     
     /**
@@ -142,7 +142,7 @@ public class NaginatorListener extends RunListener<AbstractBuild<?,?>> {
     public boolean scheduleBuild(AbstractBuild<?, ?> build, int n) {
         ParametersAction p = build.getAction(ParametersAction.class);
         CauseAction causeAction = new CauseAction(build.getAction(CauseAction.class));
-        return build.getProject().scheduleBuild(n, new NaginatorCause((Run) build), p, new NaginatorAction(), causeAction);
+        return build.getProject().scheduleBuild(n, new NaginatorUpstreamCause((Run) build), p, new NaginatorAction(), causeAction);
     }
 
     private boolean parseLog(File logFile, String regexp) throws IOException {

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorListener.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorListener.java
@@ -133,7 +133,7 @@ public class NaginatorListener extends RunListener<AbstractBuild<?,?>> {
         for (Combination c : combinations) {
             nma.addCombinationToRerun(c);
         }
-        return build.getProject().scheduleBuild(n, new NaginatorCause(), p, nma, causeAction);
+        return build.getProject().scheduleBuild(n, new NaginatorCause((Run) build), p, nma, causeAction);
     }
     
     /**
@@ -142,7 +142,7 @@ public class NaginatorListener extends RunListener<AbstractBuild<?,?>> {
     public boolean scheduleBuild(AbstractBuild<?, ?> build, int n) {
         ParametersAction p = build.getAction(ParametersAction.class);
         CauseAction causeAction = new CauseAction(build.getAction(CauseAction.class));
-        return build.getProject().scheduleBuild(n, new NaginatorCause(), p, new NaginatorAction(), causeAction);
+        return build.getProject().scheduleBuild(n, new NaginatorCause((Run) build), p, new NaginatorAction(), causeAction);
     }
 
     private boolean parseLog(File logFile, String regexp) throws IOException {

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorRetryAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorRetryAction.java
@@ -31,7 +31,7 @@ public class NaginatorRetryAction implements Action {
     public void doIndex(StaplerResponse res, @AncestorInPath AbstractBuild build) throws IOException {
         Jenkins.getInstance().checkPermission(Item.BUILD);
         ParametersAction p = build.getAction(ParametersAction.class);
-        build.getProject().scheduleBuild(0, new NaginatorCause((Run) build), p, new NaginatorAction());
+        build.getProject().scheduleBuild(0, new NaginatorUpstreamCause((Run) build), p, new NaginatorAction());
         res.sendRedirect2(build.getUpUrl());
     }
 }

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorRetryAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorRetryAction.java
@@ -31,7 +31,7 @@ public class NaginatorRetryAction implements Action {
     public void doIndex(StaplerResponse res, @AncestorInPath AbstractBuild build) throws IOException {
         Jenkins.getInstance().checkPermission(Item.BUILD);
         ParametersAction p = build.getAction(ParametersAction.class);
-        build.getProject().scheduleBuild(0, new NaginatorCause(), p, new NaginatorAction());
+        build.getProject().scheduleBuild(0, new NaginatorCause((Run) build), p, new NaginatorAction());
         res.sendRedirect2(build.getUpUrl());
     }
 }

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorUpstreamCause.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorUpstreamCause.java
@@ -1,0 +1,19 @@
+package com.chikli.hudson.plugin.naginator;
+
+import hudson.model.Cause.UpstreamCause;
+import hudson.model.Run;
+
+/**
+ * {@link Cause} for builds triggered by this plugin.
+ * @author nowell@strite.org
+ */
+public class NaginatorUpstreamCause extends UpstreamCause {
+    public NaginatorUpstreamCause(Run<?, ?> up) {
+        super(up);
+    }
+
+    @Override
+    public String getShortDescription() {
+        return Messages.NaginatorCause_Description();
+    }
+}


### PR DESCRIPTION
Right now when you trigger a job retry with naginator it creates a new build with the same parameters, but does not preserve the cause history, which is important in many upstream/downstream job flows where you wish to maintain a view into the progress of a job as it progresses through a delivery pipeline. When relying on naginator to allow auto (or manual) retry of a given step in that pipeline due to sporadic environmental failures, it should maintain the cause history as to not break the delivery history of a given upstream/downstream flow.