### PR TITLE
fix uri of redo.png

### DIFF
--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorAction/badge.jelly
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorAction/badge.jelly
@@ -1,1 +1,1 @@
-<img src="${rootURL}/plugin/naginator/redo.png" title="${%Re-scheduled after failure}"/>
+<img src="${resURL}/plugin/naginator/redo.png" title="${%Re-scheduled after failure}"/>


### PR DESCRIPTION
If jenkins's URL had prefix (ex. /jenkins), we can't reach redo.png.
So, changed to use "resURL" instead of "rootURL" to fix the issue.

Please consider this request.

Regards
