### PR TITLE
[JENKINS-29715] Control rescheduling with action

### DIFF
--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorListener.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorListener.java
@@ -6,19 +6,13 @@ import hudson.matrix.MatrixRun;
 import hudson.model.*;
 import hudson.model.listeners.RunListener;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import static hudson.model.Result.SUCCESS;
-import static hudson.model.Result.ABORTED;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.annotation.Nonnull;
 
 /**
  * @author <a href="mailto:nicolas.deloof@cloudbees.com">Nicolas De loof</a>
@@ -27,92 +21,57 @@ public class NaginatorListener extends RunListener<AbstractBuild<?,?>> {
 
 
     @Override
-    public void onCompleted(AbstractBuild<?, ?> build, TaskListener listener) {
-        if ((build.getResult() == SUCCESS) || (build.getResult() == ABORTED)) {
+    public void onCompleted(AbstractBuild<?, ?> build, @Nonnull TaskListener listener) {
+        // Do nothing for null or a single Matrix run. (Run only when all Matrix finishes)
+        if (build == null || build instanceof MatrixRun) {
             return;
         }
+        
+        int retryCount = calculateRetryCount(build);
+        
+        List<NaginatorScheduleAction> actions = build.getActions(NaginatorScheduleAction.class);
+        for (NaginatorScheduleAction action : actions) {
+            if (action.shouldSchedule(build, listener, retryCount)) {
+                int n = action.getDelay().computeScheduleDelay(build);
+                LOGGER.log(Level.FINE, "about to try to schedule a build #{0} in {1} seconds for {2}",
+                        new Object[]{build.getNumber(), n, build.getProject().getName()} );
+                
+                List<Combination> combsToRerun = new ArrayList<Combination>();
 
-        NaginatorPublisher naginator = build.getProject().getPublishersList().get(NaginatorPublisher.class);
+                if (action.isRerunMatrixPart()) {
+                    if (build instanceof MatrixBuild) {
+                        MatrixBuild mb = (MatrixBuild) build;
+                        List<MatrixRun> matrixRuns = mb.getRuns();
 
-        // JENKINS-13791
-        if (naginator == null) {
-            return;
-        }
-
-        // If we're not set to rerun if unstable, and the build's unstable, return true.
-        if ((!naginator.isRerunIfUnstable()) && (build.getResult() == Result.UNSTABLE)) {
-            return;
-        }
-
-        // Do nothing for a single Matrix run. (Run only when all Matrix finishes)
-        if (build instanceof MatrixRun) {
-            return;
-        }
-
-        // If we're supposed to check for a regular expression in the build output before
-        // scheduling a new build, do so.
-        if (naginator.isCheckRegexp()) {
-            LOGGER.log(Level.FINEST, "Got checkRegexp == true");
-
-            String regexpForRerun = naginator.getRegexpForRerun();
-            if ((regexpForRerun !=null) && (!regexpForRerun.equals(""))) {
-                LOGGER.log(Level.FINEST, "regexpForRerun - {0}", regexpForRerun);
-
-                try {
-                    // If parseLog returns false, we didn't find the regular expression,
-                    // so return true.
-                    if (!parseLog(build.getLogFile(), regexpForRerun)) {
-                        LOGGER.log(Level.FINEST, "regexp not in logfile");
-                        return;
-                    }
-                } catch (IOException e) {
-                    e.printStackTrace(listener
-                                      .error("error while parsing logs for naginator - forcing rebuild."));
-                }
-            }
-        }
-
-        if (canSchedule(build, naginator)) {
-            int n = naginator.getDelay().computeScheduleDelay(build);
-            LOGGER.log(Level.FINE, "about to try to schedule a build #{0} in {1} seconds for {2}",
-                    new Object[]{build.getNumber(), n, build.getProject().getName()} );
-            
-            List<Combination> combsToRerun = new ArrayList<Combination>();
-
-            if (naginator.isRerunMatrixPart()) {
-                if (build instanceof MatrixBuild) {
-                    MatrixBuild mb = (MatrixBuild) build;
-                    List<MatrixRun> matrixRuns = mb.getRuns();
-
-                    for(MatrixRun r : matrixRuns) {
-                        if (r.getNumber() == build.getNumber()) {
-                            if ((r.getResult() == SUCCESS) || (r.getResult() == ABORTED)) {
-                                continue;
+                        for (MatrixRun r : matrixRuns) {
+                            if (r.getNumber() == build.getNumber()) {
+                                if (!action.shouldScheduleForMatrixRun(r, listener)) {
+                                    continue;
+                                }
+                                
+                                LOGGER.log(Level.FINE, "add combination to matrix rerun ({0})", r.getParent().getCombination().toString());
+                                combsToRerun.add(r.getParent().getCombination());    
                             }
-                            if ((!naginator.isRerunIfUnstable()) && (r.getResult() == Result.UNSTABLE)) {
-                                continue;
-                            }
-                            
-                            LOGGER.log(Level.FINE, "add combination to matrix rerun ({0})", r.getParent().getCombination().toString());
-                            combsToRerun.add(r.getParent().getCombination());    
                         }
-                    }
 
+                    }
+                }
+
+                if (!combsToRerun.isEmpty()) {
+                    LOGGER.log(Level.FINE, "schedule matrix rebuild");
+                    scheduleMatrixBuild(build, combsToRerun, n);
+                } else {
+                    scheduleBuild(build, n);
                 }
             }
-
-            if (!combsToRerun.isEmpty()) {
-                LOGGER.log(Level.FINE, "schedule matrix rebuild");
-                scheduleMatrixBuild(build, combsToRerun, n);
-            } else {
-                scheduleBuild(build, n);
-            }
-        } else {
-            LOGGER.log(Level.FINE, "max number of schedules for #{0} build, project {1}",
-                    new Object[]{build.getNumber(), build.getProject().getName()} );
         }
     }
 
+    /**
+     * @deprecated use {@link NaginatorScheduleAction#shouldSchedule(Run, TaskListener, int)}
+     * to control scheduling.
+     */
+    @Deprecated
     public boolean canSchedule(Run build, NaginatorPublisher naginator) {
         Run r = build;
         int max = naginator.getMaxSchedule();
@@ -128,6 +87,16 @@ public class NaginatorListener extends RunListener<AbstractBuild<?,?>> {
         return n < max;
     }
 
+    private int calculateRetryCount(@Nonnull Run<?, ?> r) {
+        int n = 0;
+        
+        while (r != null && r.getAction(NaginatorAction.class) != null) {
+            r = r.getPreviousBuild();
+            n++;
+        }
+        return n;
+    }
+    
     public boolean scheduleMatrixBuild(AbstractBuild<?, ?> build, List<Combination> combinations, int n) {
         NaginatorMatrixAction nma = new NaginatorMatrixAction();
         for (Combination c : combinations) {
@@ -141,32 +110,6 @@ public class NaginatorListener extends RunListener<AbstractBuild<?,?>> {
      */
     public boolean scheduleBuild(AbstractBuild<?, ?> build, int n) {
         return NaginatorRetryAction.scheduleBuild(build, n);
-    }
-
-    private boolean parseLog(File logFile, String regexp) throws IOException {
-
-        if (regexp == null) {
-            return false;
-        }
-
-        // Assume default encoding and text files
-        String line;
-        Pattern pattern = Pattern.compile(regexp);
-        BufferedReader reader = null;
-        try {
-          reader = new BufferedReader(new FileReader(logFile));
-          while ((line = reader.readLine()) != null) {
-              Matcher matcher = pattern.matcher(line);
-              if (matcher.find()) {
-                  return true;
-              }
-          }
-          return false;
-        }
-        finally {
-          if(reader != null)
-            reader.close();
-        }
     }
 
     private static final Logger LOGGER = Logger.getLogger(NaginatorListener.class.getName());

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisher.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisher.java
@@ -2,6 +2,8 @@ package com.chikli.hudson.plugin.naginator;
 
 import hudson.Extension;
 import hudson.Launcher;
+import hudson.matrix.MatrixRun;
+import hudson.matrix.MatrixBuild;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
@@ -87,7 +89,16 @@ public class NaginatorPublisher extends Notifier {
 
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-        // Nothing to do during the build, see NaginatorListener
+        if (build instanceof MatrixRun) {
+            MatrixBuild parent = ((MatrixRun)build).getParentBuild();
+            if (parent.getAction(NaginatorPublisherScheduleAction.class) == null) {
+                // No strict exclusion is required
+                // as it doesn't matter if the action gets duplicated.
+                parent.addAction(new NaginatorPublisherScheduleAction(this));
+            }
+        } else {
+            build.addAction(new NaginatorPublisherScheduleAction(this));
+        }
         return true;
     }
 

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisherScheduleAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisherScheduleAction.java
@@ -1,0 +1,121 @@
+package com.chikli.hudson.plugin.naginator;
+
+import hudson.matrix.MatrixRun;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+/**
+ * Used from {@link NaginatorPublisher} to mark a build to be reshceduled.
+ */
+public class NaginatorPublisherScheduleAction extends NaginatorScheduleAction {
+    private static final Logger LOGGER = Logger.getLogger(NaginatorPublisherScheduleAction.class.getName());
+    
+    private final String regexpForRerun;
+    private final boolean rerunIfUnstable;
+    private final boolean checkRegexp;
+    
+    public NaginatorPublisherScheduleAction(NaginatorPublisher publisher) {
+        super(publisher.getMaxSchedule(), publisher.getDelay(), publisher.isRerunMatrixPart());
+        this.regexpForRerun = publisher.getRegexpForRerun();
+        this.rerunIfUnstable = publisher.isRerunIfUnstable();
+        this.checkRegexp = publisher.isCheckRegexp();
+    }
+    
+    @CheckForNull
+    public String getRegexpForRerun() {
+        return regexpForRerun;
+    }
+    
+    public boolean isRerunIfUnstable() {
+        return rerunIfUnstable;
+    }
+    
+    public boolean isCheckRegexp() {
+        return checkRegexp;
+    }
+    
+    @Override
+    public boolean shouldSchedule(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener, int retryCount) {
+        if ((run.getResult() == Result.SUCCESS) || (run.getResult() == Result.ABORTED)) {
+            return false;
+        }
+        
+        // If we're not set to rerun if unstable, and the build's unstable, return true.
+        if ((!isRerunIfUnstable()) && (run.getResult() == Result.UNSTABLE)) {
+            return false;
+        }
+        
+        // If we're supposed to check for a regular expression in the build output before
+        // scheduling a new build, do so.
+        if (isCheckRegexp()) {
+            LOGGER.log(Level.FINEST, "Got checkRegexp == true");
+            
+            String regexpForRerun = getRegexpForRerun();
+            if ((regexpForRerun != null) && (!regexpForRerun.equals(""))) {
+                LOGGER.log(Level.FINEST, "regexpForRerun - {0}", regexpForRerun);
+                
+                try {
+                    // If parseLog returns false, we didn't find the regular expression,
+                    // so return true.
+                    if (!parseLog(run.getLogFile(), regexpForRerun)) {
+                        LOGGER.log(Level.FINEST, "regexp not in logfile");
+                        return false;
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace(listener
+                                      .error("error while parsing logs for naginator - forcing rebuild."));
+                }
+            }
+        }
+        
+        return super.shouldSchedule(run, listener, retryCount);
+    }
+
+    @Override
+    public boolean shouldScheduleForMatrixRun(@Nonnull MatrixRun run, @Nonnull TaskListener listener) {
+        if ((run.getResult() == Result.SUCCESS) || (run.getResult() == Result.ABORTED)) {
+            return false;
+        }
+        if ((!isRerunIfUnstable()) && (run.getResult() == Result.UNSTABLE)) {
+            return false;
+        }
+        return true;
+    }
+    
+    private boolean parseLog(File logFile, @Nonnull String regexp) throws IOException {
+        // TODO annotate `logFile` with `@Nonnull`
+        // after upgrading the target Jenkins to 1.568 or later.
+
+        // Assume default encoding and text files
+        String line;
+        Pattern pattern = Pattern.compile(regexp);
+        BufferedReader reader = null;
+        try {
+            reader = new BufferedReader(new FileReader(logFile));
+            while ((line = reader.readLine()) != null) {
+                Matcher matcher = pattern.matcher(line);
+                if (matcher.find()) {
+                    return true;
+                }
+            }
+            return false;
+        } finally {
+            if (reader != null) {
+                reader.close();
+            }
+        }
+    }
+}

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorScheduleAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorScheduleAction.java
@@ -1,0 +1,125 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2015 IKEDA Yasuyuki
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.chikli.hudson.plugin.naginator;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+import hudson.matrix.MatrixRun;
+import hudson.model.Action;
+import hudson.model.InvisibleAction;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+/**
+ * {@link Action} to mark a build to be rescheduled by {@link NaginatorListener}.
+ * Be aware that you have to add this action to the parent build
+ * if the build is the child of another build (e.g. multi-configuration projects).
+ */
+public class NaginatorScheduleAction extends InvisibleAction {
+    private final int maxSchedule;
+    private final ScheduleDelay delay;
+    private final boolean rerunMatrixPart;
+    
+    /**
+     * Should always reschedule the build.
+     */
+    public NaginatorScheduleAction() {
+        this(0);
+    }
+    
+    /**
+     * Should reschedule the build for specified times.
+     * 
+     * @param maxSchedule max times to reschedule the build. Less or equal to 0 indicates "always".
+     */
+    public NaginatorScheduleAction(int maxSchedule) {
+        this(maxSchedule, null, false);
+    }
+    
+    /**
+     * Should reschedule the build for specified times.
+     * 
+     * @param maxSchedule max times to reschedule the build. Less or equal to 0 indicates "always".
+     * @param delay A scheduling policy to trigger a new build.
+     * @param rerunMatrixPart tests matrix child builds and triggers only failed parts.
+     */
+    public NaginatorScheduleAction(int maxSchedule, @CheckForNull ScheduleDelay delay, boolean rerunMatrixPart) {
+        this.maxSchedule = maxSchedule;
+        this.delay = (delay != null) ? delay : new ProgressiveDelay(5 * 60, 3 * 60 * 60);
+        this.rerunMatrixPart = rerunMatrixPart;
+    }
+    
+    /**
+     * The max times to reschedule the build.
+     * Less or equal to 0 indicates "always".
+     * 
+     * @return the max times to reschedule the build.
+     */
+    public int getMaxSchedule() {
+        return maxSchedule;
+    }
+    
+    /**
+     * @return A scheduling policy to trigger a new build
+     */
+    @Nonnull
+    public ScheduleDelay getDelay() {
+        return delay;
+    }
+    
+    /**
+     * @return whether to test each child builds to reschedule for multi-configuration builds.
+     */
+    public boolean isRerunMatrixPart() {
+        return rerunMatrixPart;
+    }
+    
+    /**
+     * Tests whether {@link NaginatorListener} should reschedule the build.
+     * You can override this method to reschedule the build conditionally.
+     * <code>retryCount</code> is passed with 0 when this is the first time
+     * to reschedule the build.
+     * 
+     * @param run a build to test. never be a {@link MatrixRun}
+     * @param listener The listener for this build. This can be used to produce log messages, for example, which becomes a part of the "console output" of this build. But when this method runs, the build is considered completed, so its status cannot be changed anymore.
+     * @param retryCount the count the build is rescheduled.
+     * @return whether to reschedule the build.
+     */
+    public boolean shouldSchedule(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener, int retryCount) {
+        return getMaxSchedule() <= 0 || retryCount < getMaxSchedule();
+    }
+    
+    /**
+     * A test for each child builds of multi-configuration builds.
+     * You can filter child builds to reschedule.
+     * 
+     * @param run
+     * @return
+     */
+    public boolean shouldScheduleForMatrixRun(@Nonnull MatrixRun run, @Nonnull TaskListener listener) {
+        return true;
+    }
+}

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorListenerTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorListenerTest.java
@@ -24,6 +24,14 @@ import hudson.tasks.Publisher;
 import net.sf.json.JSONObject;
 
 public class NaginatorListenerTest extends HudsonTestCase {
+    @Override
+    protected void tearDown() throws Exception {
+        try {
+            super.tearDown();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
     
     private final static class MyBuilder extends Builder {
         private final String text;

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorPublisherTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorPublisherTest.java
@@ -1,0 +1,159 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2015 IKEDA Yasuyuki
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.chikli.hudson.plugin.naginator;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import hudson.AbortException;
+import hudson.Launcher;
+import hudson.matrix.Axis;
+import hudson.matrix.AxisList;
+import hudson.matrix.Combination;
+import hudson.matrix.MatrixRun;
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixProject;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.tasks.Builder;
+
+/**
+ * Tests for {@link NaginatorPublisher}.
+ * Many tests for {@link NaginatorPublisher} are also in {@link NaginatorListenerTest}
+ */
+public class NaginatorPublisherTest {
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+    
+    private static class FailSpecificAxisBuilder extends Builder {
+        private final String combinationFilterToFail;
+        
+        public FailSpecificAxisBuilder(String combinationFilterToFail) {
+            this.combinationFilterToFail = combinationFilterToFail;
+        }
+        
+        @Override
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                throws InterruptedException, IOException {
+            if (!(build instanceof MatrixRun)) {
+                throw new AbortException("only applicable for MatrixRun");
+            }
+            
+            MatrixRun run = (MatrixRun) build;
+            
+            if (run.getParent().getCombination().evalGroovyExpression(
+                    run.getParent().getParent().getAxes(),
+                    combinationFilterToFail
+            )) {
+                throw new AbortException("Combination matches the filter.");
+            }
+            
+            return true;
+        }
+    }
+    
+    /**
+     * Disabling {@link NaginatorPublisher#isRerunIfUnstable()}
+     * should trigger all children.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testMatrixBuildWithoutRerunMatrixPart() throws Exception {
+        final int maxSchedule = 2;
+        
+        MatrixProject p = j.createMatrixProject();
+        AxisList axes = new AxisList(
+                new Axis("axis1", "1", "2"),
+                new Axis("axis2", "1", "2")
+        );
+        p.setAxes(axes);
+        p.getBuildersList().add(new FailSpecificAxisBuilder("(axis1=='1' && axis2=='2') || (axis1=='2' && axis2=='1')"));
+        p.getPublishersList().add(new NaginatorPublisher(
+                null,   // regexpForRerun
+                false,  // rerunIfUnstable
+                false,  // rerunMatrixPart
+                false,  // checkRegexp
+                maxSchedule,
+                new FixedDelay(0)
+        ));
+        
+        p.scheduleBuild2(0);
+        j.waitUntilNoActivity();
+        
+        assertEquals(maxSchedule + 1, p.getLastBuild().number);
+        
+        // (1, 1), (1, 2), (2, 1), (2, 2) are rescheduled.
+        MatrixBuild b = p.getLastBuild();
+        assertNotNull(b.getExactRun(new Combination(axes, "1", "1")));
+        assertNotNull(b.getExactRun(new Combination(axes, "1", "2")));
+        assertNotNull(b.getExactRun(new Combination(axes, "2", "1")));
+        assertNotNull(b.getExactRun(new Combination(axes, "2", "2")));
+    }
+        
+    /**
+     * Enabling {@link NaginatorPublisher#isRerunIfUnstable()}
+     * should trigger only failed children.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testMatrixBuildWithRerunMatrixPart() throws Exception {
+        final int maxSchedule = 2;
+        
+        MatrixProject p = j.createMatrixProject();
+        AxisList axes = new AxisList(
+                new Axis("axis1", "1", "2"),
+                new Axis("axis2", "1", "2")
+        );
+        p.setAxes(axes);
+        p.getBuildersList().add(new FailSpecificAxisBuilder("(axis1=='1' && axis2=='2') || (axis1=='2' && axis2=='1')"));
+        p.getPublishersList().add(new NaginatorPublisher(
+                null,   // regexpForRerun
+                false,  // rerunIfUnstable
+                true,  // rerunMatrixPart
+                false,  // checkRegexp
+                maxSchedule,
+                new FixedDelay(0)
+        ));
+        
+        p.scheduleBuild2(0);
+        j.waitUntilNoActivity();
+        
+        assertEquals(maxSchedule + 1, p.getLastBuild().number);
+        
+        // (1, 2), (2, 1) are rescheduled.
+        MatrixBuild b = p.getLastBuild();
+        assertNull(b.getExactRun(new Combination(axes, "1", "1")));
+        assertNotNull(b.getExactRun(new Combination(axes, "1", "2")));
+        assertNotNull(b.getExactRun(new Combination(axes, "2", "1")));
+        assertNull(b.getExactRun(new Combination(axes, "2", "2")));
+    }
+}

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorScheduleActionTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorScheduleActionTest.java
@@ -1,0 +1,411 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2015 IKEDA Yasuyuki
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.chikli.hudson.plugin.naginator;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+
+import hudson.Launcher;
+import hudson.matrix.Axis;
+import hudson.matrix.AxisList;
+import hudson.matrix.Combination;
+import hudson.matrix.MatrixRun;
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixProject;
+import hudson.model.AbstractBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleBuild;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tasks.Builder;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ *
+ */
+public class NaginatorScheduleActionTest {
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+    
+    public static class ScheduleActionBuilder extends Builder {
+        private final NaginatorScheduleAction[] actions;
+        
+        public ScheduleActionBuilder(NaginatorScheduleAction... actions) {
+            this.actions = actions;
+        }
+        
+        @Override
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                throws InterruptedException, IOException {
+            if (build instanceof MatrixRun) {
+                MatrixBuild parent = ((MatrixRun) build).getParentBuild();
+                if (parent.getAction(NaginatorScheduleAction.class) == null) {
+                    for (NaginatorScheduleAction action : actions) {
+                        parent.addAction(action);
+                    }
+                }
+            } else {
+                for (NaginatorScheduleAction action : actions) {
+                    build.addAction(action);
+                }
+            }
+            return true;
+        }
+    }
+    
+    private static class AlwaysFalseScheduleAction extends NaginatorScheduleAction {
+        public AlwaysFalseScheduleAction(int maxSchedule, ScheduleDelay delay, boolean rerunMatrixPart) {
+            super(maxSchedule, delay, rerunMatrixPart);
+        }
+        
+        @Override
+        public boolean shouldSchedule(Run<?, ?> run, TaskListener listener, int retryCount) {
+            return false;
+        }
+    }
+    
+    private static class MatrixConfigurationScheduleAction extends NaginatorScheduleAction {
+        private final String combinationFilter;
+        
+        public MatrixConfigurationScheduleAction(String combinationFilter, int maxSchedule, ScheduleDelay delay, boolean rerunMatrixPart) {
+            super(maxSchedule, delay, rerunMatrixPart);
+            this.combinationFilter = combinationFilter;
+        }
+        
+        @Override
+        public boolean shouldScheduleForMatrixRun(MatrixRun run, TaskListener listener) {
+            return run.getParent().getCombination().evalGroovyExpression(
+                    run.getParent().getParent().getAxes(),
+                    combinationFilter
+            );
+        }
+    }
+    
+    /**
+     * {@link NaginatorScheduleAction#shouldSchedule(Run, TaskListener, int)}
+     * should be true only while <code>retryCount</code> is
+     * under <code>maxSchedule</code>
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testShouldReschedule() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        FreeStyleBuild b = p.scheduleBuild2(0).get();
+        
+        NaginatorScheduleAction target = new NaginatorScheduleAction(2);
+        assertTrue(target.shouldSchedule(b, TaskListener.NULL, 0));
+        assertTrue(target.shouldSchedule(b, TaskListener.NULL, 1));
+        assertFalse(target.shouldSchedule(b, TaskListener.NULL, 2));
+    }
+        
+    /**
+     * {@link NaginatorScheduleAction#shouldSchedule(Run, TaskListener, int)}
+     * should be true always true when <code>maxSchedule</code> is 0.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testShouldRescheduleWithMaxScheduleIs0() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        FreeStyleBuild b = p.scheduleBuild2(0).get();
+        
+        NaginatorScheduleAction target = new NaginatorScheduleAction();
+        assertEquals(0, target.getMaxSchedule());
+        assertTrue(target.shouldSchedule(b, TaskListener.NULL, 0));
+        assertTrue(target.shouldSchedule(b, TaskListener.NULL, 100));
+        assertTrue(target.shouldSchedule(b, TaskListener.NULL, 2000));
+    }
+        
+    /**
+     * {@link NaginatorScheduleAction#shouldSchedule(Run, TaskListener, int)}
+     * should be true always true when <code>maxSchedule</code> is under 0.
+     * This is not a correct usage but a fail-safe.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testShouldRescheduleWithMaxScheduleIsMinus() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        FreeStyleBuild b = p.scheduleBuild2(0).get();
+        
+        NaginatorScheduleAction target = new NaginatorScheduleAction(-1);
+        assertTrue(target.shouldSchedule(b, TaskListener.NULL, 0));
+        assertTrue(target.shouldSchedule(b, TaskListener.NULL, 100));
+        assertTrue(target.shouldSchedule(b, TaskListener.NULL, 2000));
+    }
+    
+    /**
+     * {@link NaginatorPublisher} should not reschedule a build
+     * without {@link NaginatorScheduleAction}.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testNoNaginatorScheduleAction() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.getBuildersList().add(new ScheduleActionBuilder());
+        p.scheduleBuild2(0);
+        j.waitUntilNoActivity();
+        
+        // no reschedule.
+        assertEquals(1, p.getLastBuild().number);
+    }
+    
+    /**
+     * {@link NaginatorScheduleAction} should have 
+     * {@link NaginatorPublisher} reschedule the build
+     * with times specified with <code>maxSchedule</code>
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testReschedule() throws Exception {
+        final int maxSchedule = 2;
+        
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.getBuildersList().add(new ScheduleActionBuilder(
+                new NaginatorScheduleAction(
+                        maxSchedule,
+                        new FixedDelay(0),
+                        false
+                )
+        ));
+        p.scheduleBuild2(0);
+        j.waitUntilNoActivity();
+        
+        assertEquals(maxSchedule + 1, p.getLastBuild().number);
+    }
+        
+    /**
+     * {@link NaginatorScheduleAction#shouldSchedule(Run, TaskListener, int)}
+     * returning 0 should not have {@link NaginatorPublisher}
+     * reschedule the build.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testNotRescheduledWithShouldRescheduleReturning0() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.getBuildersList().add(new ScheduleActionBuilder(
+                new AlwaysFalseScheduleAction(
+                        2,
+                        new FixedDelay(0),
+                        false
+                )
+        ));
+        p.scheduleBuild2(0);
+        j.waitUntilNoActivity();
+        
+        // no reschedule.
+        assertEquals(1, p.getLastBuild().number);
+    }
+        
+    /**
+     * When there are multiple {@link NaginatorScheduleAction}s,
+     * {@link NaginatorPublisher} should reschedule the build
+     * if any of them return true.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testMultipleNaginatorScheduleAction() throws Exception {
+        final int maxSchedule = 2;
+        
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.getBuildersList().add(new ScheduleActionBuilder(
+                new AlwaysFalseScheduleAction(
+                        maxSchedule,
+                        new FixedDelay(0),
+                        false
+                ),
+                new NaginatorScheduleAction(
+                        maxSchedule,
+                        new FixedDelay(0),
+                        false
+                )
+        ));
+        p.scheduleBuild2(0);
+        j.waitUntilNoActivity();
+        
+        assertEquals(maxSchedule + 1, p.getLastBuild().number);
+    }
+    
+    /**
+     * The default behavior of {@link NaginatorScheduleAction}
+     * for multi-configuration projects is to run all children
+     * even if <code>rerunMatrixPart</code> is set.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testMatrixWithRerunMatrixPartWithoutFiltering() throws Exception {
+        final int maxSchedule = 2;
+        
+        MatrixProject p = j.createMatrixProject();
+        AxisList axes = new AxisList(
+                new Axis("axis1", "1", "2"),
+                new Axis("axis2", "1", "2")
+        );
+        p.setAxes(axes);
+        p.setCombinationFilter("!(axis1=='2' && axis2=='2')");
+        p.getBuildersList().add(new ScheduleActionBuilder(
+                new NaginatorScheduleAction(
+                        maxSchedule,
+                        new FixedDelay(0),
+                        true
+                )
+        ));
+        p.scheduleBuild2(0);
+        j.waitUntilNoActivity();
+        
+        assertEquals(maxSchedule + 1, p.getLastBuild().number);
+        
+        // (1, 1), (1, 2), (2, 1) are scheduled
+        MatrixBuild b = p.getLastBuild();
+        assertNotNull(b.getExactRun(new Combination(axes, "1", "1")));
+        assertNotNull(b.getExactRun(new Combination(axes, "1", "2")));
+        assertNotNull(b.getExactRun(new Combination(axes, "2", "1")));
+        assertNull(b.getExactRun(new Combination(axes, "2", "2")));
+    }
+    
+    /**
+     * Overriding {@link NaginatorScheduleAction#shouldScheduleForMatrixRun(MatrixRun, TaskListener)}
+     * allows filter children to reschedule.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testMatrixWithRerunMatrixPartWithFiltering() throws Exception {
+        final int maxSchedule = 1;
+        
+        MatrixProject p = j.createMatrixProject();
+        AxisList axes = new AxisList(
+                new Axis("axis1", "1", "2"),
+                new Axis("axis2", "1", "2")
+        );
+        p.setAxes(axes);
+        p.setCombinationFilter("!(axis1=='2' && axis2=='2')");
+        p.getBuildersList().add(new ScheduleActionBuilder(
+                new MatrixConfigurationScheduleAction(
+                        "(axis1=='1' && axis2=='2') || (axis1=='2' && axis2=='1')",
+                        maxSchedule,
+                        new FixedDelay(0),
+                        true
+                )
+        ));
+        p.scheduleBuild2(0);
+        j.waitUntilNoActivity();
+        
+        assertEquals(maxSchedule + 1, p.getLastBuild().number);
+        
+        // (1, 2), (2, 1) are scheduled
+        MatrixBuild b = p.getLastBuild();
+        assertNull(b.getExactRun(new Combination(axes, "1", "1")));
+        assertNotNull(b.getExactRun(new Combination(axes, "1", "2")));
+        assertNotNull(b.getExactRun(new Combination(axes, "2", "1")));
+        assertNull(b.getExactRun(new Combination(axes, "2", "2")));
+    }
+    
+    /**
+     * Filtering out all children cause trigger all children.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testMatrixWithNoChildren() throws Exception {
+        final int maxSchedule = 1;
+        
+        MatrixProject p = j.createMatrixProject();
+        AxisList axes = new AxisList(
+                new Axis("axis1", "1", "2"),
+                new Axis("axis2", "1", "2")
+        );
+        p.setAxes(axes);
+        p.setCombinationFilter("!(axis1=='2' && axis2=='2')");
+        p.getBuildersList().add(new ScheduleActionBuilder(
+                new MatrixConfigurationScheduleAction(
+                        "false",
+                        1,
+                        new FixedDelay(0),
+                        true
+                )
+        ));
+        p.scheduleBuild2(0);
+        j.waitUntilNoActivity();
+        
+        assertEquals(maxSchedule + 1, p.getLastBuild().number);
+        
+        // (1, 1), (1, 2), (2, 1) are scheduled
+        MatrixBuild b = p.getLastBuild();
+        assertNotNull(b.getExactRun(new Combination(axes, "1", "1")));
+        assertNotNull(b.getExactRun(new Combination(axes, "1", "2")));
+        assertNotNull(b.getExactRun(new Combination(axes, "2", "1")));
+        assertNull(b.getExactRun(new Combination(axes, "2", "2")));
+    }
+    
+    /**
+     * Unsetting <code>rerunMatrixPart</code> triggers all children
+     * even if overriding {@link NaginatorScheduleAction#shouldScheduleForMatrixRun(MatrixRun, TaskListener)}
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testMatrixWithoutRerunMatrixPart() throws Exception {
+        final int maxSchedule = 1;
+        
+        MatrixProject p = j.createMatrixProject();
+        AxisList axes = new AxisList(
+                new Axis("axis1", "1", "2"),
+                new Axis("axis2", "1", "2")
+        );
+        p.setAxes(axes);
+        p.setCombinationFilter("!(axis1=='2' && axis2=='2')");
+        p.getBuildersList().add(new ScheduleActionBuilder(
+                new MatrixConfigurationScheduleAction(
+                        "(axis1=='1' && axis2=='2') || (axis1=='2' && axis2=='1')",
+                        1,
+                        new FixedDelay(0),
+                        false
+                )
+        ));
+        p.scheduleBuild2(0);
+        j.waitUntilNoActivity();
+        
+        assertEquals(maxSchedule + 1, p.getLastBuild().number);
+        
+        // (1, 1), (1, 2), (2, 1) are scheduled
+        MatrixBuild b = p.getLastBuild();
+        assertNotNull(b.getExactRun(new Combination(axes, "1", "1")));
+        assertNotNull(b.getExactRun(new Combination(axes, "1", "2")));
+        assertNotNull(b.getExactRun(new Combination(axes, "2", "1")));
+        assertNull(b.getExactRun(new Combination(axes, "2", "2")));
+    }
+}


### PR DESCRIPTION
[JENKINS-29715](https://issues.jenkins-ci.org/browse/JENKINS-29715)
[Build-timeout plugin](https://wiki.jenkins-ci.org/display/JENKINS/Build-timeout+Plugin) plans a new feature to reschedule the build when timeout occurs.
(jenkinsci/build-timeout-plugin#44, jenkinsci/build-timeout-plugin#45).
The rescheduling feature is already provided by naginator plugin and we want to reuse that feature from build-timeout plugin.

This change introduces `NaginatorScheduleAction`.
You can make naginator reschedule a build by adding `NaginatorScheduleAction` to the build.

I changed to `NaginatorPublisher` to use that, and it allows naginator plugin works with [Flexible Publish plugin](https://wiki.jenkins-ci.org/display/JENKINS/Flexible+Publish+Plugin) ([JENKINS-23984](https://issues.jenkins-ci.org/browse/JENKINS-23984)).

Outline of the change:
* Introduced `NaginatorScheduleAction`, which provides following features:
    * Check the retrying count and decides whether to reschedule.
    * Always rerun all matrix children.
* `NaginatorListener` now decides whether to reschedule the build with `NaginatorScheduleAction`. `NaginatorListener` now does followings:
    * Calcuate retying counts.
    * Reschedule the build.
* `NaginatorPublisher` defines `NaginatorPublisher.Action` extending `NaginatorScheduleAction` which does almost all what was done in `NaginatorListener`. Many codes are copied from `NaginatorListener`:
    * Check the build result
    * Check the build log.