### PR TITLE
Adding regex support for matrix run logs

### DIFF
--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorListener.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorListener.java
@@ -61,8 +61,9 @@ public class NaginatorListener extends RunListener<AbstractBuild<?,?>> {
                 if (build instanceof MatrixBuild) {
                     MatrixBuild mb = (MatrixBuild)build;
                     List<MatrixRun> matrixRuns = mb.getRuns();
+                    boolean regexFound = false;
 
-					// for matrix builds, check the logs of all matrix runs
+                    // for matrix builds, check the logs of all matrix runs
                     for (MatrixRun r : matrixRuns) {
                         if (r.getNumber() == build.getNumber()) {
                             if ((r.getResult() == SUCCESS) || (r.getResult() == ABORTED)) {
@@ -77,13 +78,18 @@ public class NaginatorListener extends RunListener<AbstractBuild<?,?>> {
                                     // found a match in one of the matrix runs
                                     // this is reason enough to restart the (parent) matrix job
                                     LOGGER.log(Level.FINEST, "regexp found in logfile");
+                                    regexFound = true;
                                     break;
                                 }
                             } catch (IOException e) {
                                 e.printStackTrace(listener
                                       .error("error while parsing logs for naginator - forcing rebuild."));
-                            }                            
+                            }
                         }
+                    }
+                    // return if no regex was found in the matrix run logs. reschedule otherwise
+                    if (!regexFound) {
+                        return;
                     }
                 } else {
                     try {

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisher.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisher.java
@@ -26,7 +26,7 @@ public class NaginatorPublisher extends Notifier {
     private final boolean rerunIfUnstable;
     private final boolean rerunMatrixPart;
     private final boolean checkRegexp;
-
+    private final boolean parseMatrixRuns;
     private ScheduleDelay delay;
 
     private int maxSchedule;
@@ -38,17 +38,29 @@ public class NaginatorPublisher extends Notifier {
         this(regexpForRerun, rerunIfUnstable, false, checkRegexp, 0, new ProgressiveDelay(5*60, 3*60*60));
     }
 
-    @DataBoundConstructor
+    // backward compatible constructor
     public NaginatorPublisher(String regexpForRerun,
                               boolean rerunIfUnstable,
                               boolean rerunMatrixPart,
                               boolean checkRegexp,
                               int maxSchedule,
                               ScheduleDelay delay) {
+        this(regexpForRerun, rerunIfUnstable, rerunMatrixPart, checkRegexp, false, maxSchedule, delay);
+    }
+
+    @DataBoundConstructor
+    public NaginatorPublisher(String regexpForRerun,
+                              boolean rerunIfUnstable,
+                              boolean rerunMatrixPart,
+                              boolean checkRegexp,
+                              boolean parseMatrixRuns,
+                              int maxSchedule,
+                              ScheduleDelay delay) {
         this.regexpForRerun = regexpForRerun;
         this.rerunIfUnstable = rerunIfUnstable;
         this.rerunMatrixPart = rerunMatrixPart;
         this.checkRegexp = checkRegexp;
+        this.parseMatrixRuns = parseMatrixRuns;
         this.maxSchedule = maxSchedule;
         this.delay = delay;
     }
@@ -71,6 +83,10 @@ public class NaginatorPublisher extends Notifier {
     
     public boolean isCheckRegexp() {
         return checkRegexp;
+    }
+    
+    public boolean isParseMatrixRuns() {
+        return parseMatrixRuns;
     }
 
     public String getRegexpForRerun() {

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/config.jelly
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/config.jelly
@@ -24,6 +24,10 @@
         <f:entry title="${%Regular expression to search for}" field="regexpForRerun">
             <f:textbox />
         </f:entry>
+        <f:entry field="parseMatrixRuns"
+                 title="${%Search regex in matrix run logs instead of parent log}">
+            <f:checkbox />
+        </f:entry>
     </f:advanced>
 
 </j:jelly>


### PR DESCRIPTION
This implementation supports the matching of regular expressions
contained in the logs of single matrix runs. So far, with the
"regex"-option the plugin only scans the parent job's build log. Usually
this log contains little to no information about the actual problems
that occurred during the individual matrix combination runs. My approach
checks each log of the matrix job runs and rebuilds if the regex is
found in any of them. The implementation also works fine with the
"rebuild only failed parts of the matrix"-option.

------------------------------------------------
Possibly related bug:
------------------------------------------------
[JENKINS-26637] (https://issues.jenkins-ci.org/browse/JENKINS-26637)

------------------------------------------------
Job configuration:
------------------------------------------------
![matrix-job-config](https://cloud.githubusercontent.com/assets/5657657/9656542/579dcac8-5239-11e5-99a2-c5c552062acc.png)

------------------------------------------------
Matrix Parent Job - Build Log:
------------------------------------------------
![matrix-parent-build-log](https://cloud.githubusercontent.com/assets/5657657/9224111/4adeffa4-4100-11e5-8750-9f415362f453.png)

------------------------------------------------
Matrix Combination Run - Build Log:
------------------------------------------------
![matrix-run-build-log](https://cloud.githubusercontent.com/assets/5657657/9224109/4add5956-4100-11e5-9620-70678ea02ae9.png)