### PR TITLE
[JENKINS-17626] Count the number a build rescheduled precisely

### DIFF
--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorAction.java
@@ -7,6 +7,23 @@ import hudson.model.BuildBadgeAction;
  * @author: <a hef="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class NaginatorAction implements BuildBadgeAction {
+    private final int retryCount;
+
+    /**
+     * @deprecated use {@link NaginatorAction#NaginatorAction(int)}
+     */
+    @Deprecated
+    public NaginatorAction() {
+        this(0);
+    }
+
+    /**
+     * @param retryCount the number of retry this build is rescheduled for.
+     * @since 1.16
+     */
+    public NaginatorAction(int retryCount) {
+        this.retryCount = retryCount;
+    }
 
     public String getIconFileName() {
         return null;
@@ -18,5 +35,17 @@ public class NaginatorAction implements BuildBadgeAction {
 
     public String getUrlName() {
         return null;
+    }
+
+    /**
+     * Returns the number of retry this build is rescheduled for.
+     * This may be <code>0</code> for builds rescheduled with
+     * older versions of naginator-plugin.
+     * 
+     * @return the number of retry this build is rescheduled for.
+     * @since 1.16
+     */
+    public int getRetryCount() {
+        return retryCount;
     }
 }

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorMatrixAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorMatrixAction.java
@@ -12,7 +12,20 @@ import java.util.List;
 public class NaginatorMatrixAction extends NaginatorAction {
     private List<Combination> combsToRerun;
 
+    /**
+     * @deprecated use {@link NaginatorMatrixAction#NaginatorMatrixAction(int)}.
+     */
+    @Deprecated
     public NaginatorMatrixAction() {
+        this(0);
+    }
+
+    /**
+     * @param retryCount the number of retry this build is rescheduled for.
+     * @since 1.16
+     */
+    public NaginatorMatrixAction(int retryCount) {
+        super(retryCount);
         this.combsToRerun = new ArrayList<Combination>();
     }
     

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorRetryAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorRetryAction.java
@@ -37,12 +37,12 @@ public class NaginatorRetryAction implements Action {
 
     public void doIndex(StaplerResponse res, @AncestorInPath AbstractBuild build) throws IOException {
         Jenkins.getInstance().checkPermission(Item.BUILD);
-        NaginatorRetryAction.scheduleBuild(build, 0);
+        NaginatorRetryAction.scheduleBuild(build, 0, NaginatorListener.calculateRetryCount(build));
         res.sendRedirect2(build.getUpUrl());
     }
 
-    static boolean scheduleBuild(final AbstractBuild<?, ?> build, final int delay) {
-        return scheduleBuild(build, delay, new NaginatorAction());
+    static boolean scheduleBuild(final AbstractBuild<?, ?> build, final int delay, int retryCount) {
+        return scheduleBuild(build, delay, new NaginatorAction(retryCount));
     }
 
     static boolean scheduleBuild(final AbstractBuild<?, ?> build, final int delay, final NaginatorAction action) {

--- a/src/test/java/com/chikli/hudson/plugin/naginator/ProgressiveDelayTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/ProgressiveDelayTest.java
@@ -55,7 +55,7 @@ public class ProgressiveDelayTest {
     private static AbstractBuild createBuild(final boolean hasNaginatorAction, final AbstractBuild previousBuild) {
         final AbstractBuild build = mock(AbstractBuild.class);
         when(build.getPreviousBuild()).thenReturn(previousBuild);
-        when(build.getAction(NaginatorAction.class)).thenReturn(hasNaginatorAction ? new NaginatorAction() : null);
+        when(build.getAction(NaginatorAction.class)).thenReturn(hasNaginatorAction ? new NaginatorAction(0) : null);
         return build;
     }
 }


### PR DESCRIPTION
[JENKINS-17626](https://issues.jenkins-ci.org/browse/JENKINS-17626)

Naginator plugin 0.15 counts how many times the build is rescheduled by counting how many builds with `NaginatorAction` in the build history.
This results in wrong counts if there are more than one series of rescheduled builds, such as builds with different parameters.

This change stores the retrying counts in `NaginatorAction` and increments them when rescheduling new builds.