### PR TITLE
Removed matrix-project from dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,12 +71,6 @@
     
     <dependencies>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>matrix-project</artifactId>
-            <version>1.2</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.9.5</version>


### PR DESCRIPTION
Naginator-plugin includes matrix-project in its dependency.
Naginator-plugin targets Jenkins 1.554, Jenkins 1.554 still includes matrix-project feature (they are split since Jenkins 1.581), and then naginator-plugin doesn't need matrix-project in its dependency.