### PR TITLE
[FIXED JENKINS-26637] Allow regexp applied for matrix children logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,12 +71,6 @@
     
     <dependencies>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>matrix-project</artifactId>
-            <version>1.2</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.9.5</version>

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/config.jelly
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/config.jelly
@@ -17,13 +17,17 @@
     </f:entry>
 
     <f:advanced>
-        <f:entry field="checkRegexp"
+        <f:optionalBlock field="checkRegexp" inline="true"
                  title="${%Only rerun build if regular expression is found in output}">
-            <f:checkbox />
-        </f:entry>
-        <f:entry title="${%Regular expression to search for}" field="regexpForRerun">
-            <f:textbox />
-        </f:entry>
+            <f:entry title="${%Regular expression to search for}" field="regexpForRerun">
+                <f:textbox />
+            </f:entry>
+            <j:if test="${descriptor.matrixProject}">
+                <f:entry title="${%Test regular expression for the matrix parent}" field="regexpForMatrixParent">
+                    <f:checkbox />
+                </f:entry>
+            </j:if>
+        </f:optionalBlock>
     </f:advanced>
 
 </j:jelly>

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorListenerTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorListenerTest.java
@@ -7,8 +7,8 @@ import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.HudsonTestCase;
 import org.jvnet.hudson.test.FailureBuilder;
 import org.jvnet.hudson.test.SleepBuilder;
-import org.kohsuke.stapler.StaplerRequest;
 
+import com.chikli.hudson.plugin.naginator.testutils.MyBuilder;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 
@@ -19,7 +19,6 @@ import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
-import hudson.model.Descriptor;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
@@ -31,9 +30,7 @@ import hudson.model.TaskListener;
 import hudson.tasks.BuildTrigger;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
-import hudson.tasks.Builder;
 import hudson.tasks.Publisher;
-import net.sf.json.JSONObject;
 
 public class NaginatorListenerTest extends HudsonTestCase {
     @Override
@@ -45,46 +42,6 @@ public class NaginatorListenerTest extends HudsonTestCase {
         }
     }
     
-    private final static class MyBuilder extends Builder {
-        private final String text;
-        private final Result result;
-        private final int duration;
-
-        public MyBuilder(String text, Result result) {
-            super();
-            this.text = text;
-            this.result = result;
-            this.duration = 0;
-        }
-
-        private MyBuilder(String text, Result result, int duration) {
-            this.text = text;
-            this.result = result;
-            this.duration = duration;
-        }
-
-        @Override
-        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
-                               BuildListener listener) throws InterruptedException,
-                                                              IOException {
-            if (duration > 0) Thread.sleep(duration);
-
-            listener.getLogger().println(text);
-            build.setResult(result);
-            return true;
-        }
-
-        @Extension
-        public static final class DescriptorImpl extends Descriptor<Builder> {
-            public String getDisplayName() {
-                return "MyBuilder";
-            }
-            public MyBuilder newInstance(StaplerRequest req, JSONObject data) {
-                return new MyBuilder("foo", Result.SUCCESS);
-            }
-        }
-    }
-
     public void testSuccessNoRebuild() throws Exception {
         assertEquals(false, isScheduledForRetry("build log", Result.SUCCESS, "foo", false, false));
     }

--- a/src/test/java/com/chikli/hudson/plugin/naginator/testutils/MyBuilder.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/testutils/MyBuilder.java
@@ -1,0 +1,55 @@
+package com.chikli.hudson.plugin.naginator.testutils;
+
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.Descriptor;
+import hudson.model.Result;
+import hudson.tasks.Builder;
+
+import java.io.IOException;
+
+import net.sf.json.JSONObject;
+
+import org.kohsuke.stapler.StaplerRequest;
+
+public final class MyBuilder extends Builder {
+    private final String text;
+    private final Result result;
+    private final int duration;
+
+    public MyBuilder(String text, Result result) {
+        super();
+        this.text = text;
+        this.result = result;
+        this.duration = 0;
+    }
+
+    public MyBuilder(String text, Result result, int duration) {
+        this.text = text;
+        this.result = result;
+        this.duration = duration;
+    }
+
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
+                           BuildListener listener) throws InterruptedException,
+                                                          IOException {
+        if (duration > 0) Thread.sleep(duration);
+
+        listener.getLogger().println(build.getEnvironment(listener).expand(text));
+        build.setResult(result);
+        return true;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends Descriptor<Builder> {
+        public String getDisplayName() {
+            return "MyBuilder";
+        }
+        public MyBuilder newInstance(StaplerRequest req, JSONObject data) {
+            return new MyBuilder("foo", Result.SUCCESS);
+        }
+    }
+}


### PR DESCRIPTION
[JENKINS-26637](https://issues.jenkins-ci.org/browse/JENKINS-26637)

Based on #20 
Replaces #17 , #18.

Added an option for applying the regular expression to logs of matrix children.
![screenshot](https://cloud.githubusercontent.com/assets/3115961/9978865/07f947b6-5f88-11e5-8f7b-515ab25805f9.png)