### PR TITLE
[JENKINS-24903] Aborts long running regular expressions

### DIFF
--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisher.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisher.java
@@ -28,6 +28,8 @@ import java.util.logging.Logger;
  * @author Nayan Hajratwala <nayan@chikli.com>
  */
 public class NaginatorPublisher extends Notifier {
+    public final static long DEFAULT_REGEXP_TIMEOUT_MS = 30000;
+    
     private final String regexpForRerun;
     private final boolean rerunIfUnstable;
     private final boolean rerunMatrixPart;
@@ -176,9 +178,39 @@ public class NaginatorPublisher extends Notifier {
      */
     @Extension
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+        private long regexpTimeoutMs;
 
         public DescriptorImpl() {
-            super(NaginatorPublisher.class);
+            // default value
+            regexpTimeoutMs = DEFAULT_REGEXP_TIMEOUT_MS;
+            load();
+        }
+
+        /**
+         * @return timeout for regular expressions.
+         * @since 1.16.1
+         */
+        public long getRegexpTimeoutMs() {
+            return regexpTimeoutMs;
+        }
+
+        /**
+         * @param regexpTimeoutMs timeout for regular expressions.
+         * @since 1.16.1
+         */
+        public void setRegexpTimeoutMs(long regexpTimeoutMs) {
+            this.regexpTimeoutMs = regexpTimeoutMs;
+        }
+
+        /**
+         * @see hudson.model.Descriptor#configure(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObject)
+         */
+        @Override
+        public boolean configure(StaplerRequest req, JSONObject json) throws hudson.model.Descriptor.FormException {
+            setRegexpTimeoutMs(json.getLong("regexpTimeoutMs"));
+            boolean result = super.configure(req, json);
+            save();
+            return result;
         }
 
         /**

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/global.jelly
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/global.jelly
@@ -1,3 +1,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <!-- nothing to configure -->
+<f:section title="${descriptor.displayName}">
+  <f:entry field="regexpTimeoutMs" title="${%Timeout for regular expressions (ms)}">
+    <f:textbox />
+  </f:entry>
+</f:section>
 </j:jelly>

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/help-regexpTimeoutMs.html
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/help-regexpTimeoutMs.html
@@ -1,0 +1,4 @@
+<div>
+Milliseconds to abort regular expressions.
+Some regular expressions can cause long execution time and exhaust CPUs.
+</div>

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorListenerTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorListenerTest.java
@@ -235,4 +235,21 @@ public class NaginatorListenerTest extends HudsonTestCase {
                 }
         ).size());
     }
+    
+    @Bug(24903)
+    public void testCatastorophicRegularExpression() throws Exception {
+        FreeStyleProject p = createFreeStyleProject();
+        p.getBuildersList().add(new MyBuilder("0000000000000000000000000000000000000000000000000000", Result.FAILURE));
+        p.getPublishersList().add(new NaginatorPublisher(
+                "(0*)*NOSUCHSTRING",               // regexpForRerun
+                false,                  // rerunIfUnstable
+                false,                  // rerunMatrixPart
+                true,                   // checkRegexp
+                1,                      // maxSchedule
+                new FixedDelay(0)       // delay
+        ));
+        
+        p.scheduleBuild2(0);
+        waitUntilNoActivityUpTo(10 * 1000);
+    }
 }

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorListenerTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorListenerTest.java
@@ -249,6 +249,9 @@ public class NaginatorListenerTest extends HudsonTestCase {
                 new FixedDelay(0)       // delay
         ));
         
+        ((NaginatorPublisher.DescriptorImpl)jenkins.getDescriptor(NaginatorPublisher.class))
+            .setRegexpTimeoutMs(1000);
+        
         p.scheduleBuild2(0);
         waitUntilNoActivityUpTo(10 * 1000);
     }

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorPublisherTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorPublisherTest.java
@@ -328,4 +328,19 @@ public class NaginatorPublisherTest {
         assertFalse(p.getPublishersList().get(NaginatorPublisher.class).isRegexpForMatrixParent());
         j.assertEqualDataBoundBeans(expected, p.getPublishersList().get(NaginatorPublisher.class));
     }
+    
+    @Test
+    public void testRegexpTimeoutMsInSystemConfiguration() throws Exception {
+        NaginatorPublisher.DescriptorImpl d = (NaginatorPublisher.DescriptorImpl)j.jenkins.getDescriptor(NaginatorPublisher.class);
+        d.setRegexpTimeoutMs(NaginatorPublisher.DEFAULT_REGEXP_TIMEOUT_MS);
+        d.save();       // ensure the default value is saved to the file.
+        
+        // set to the memory, but not saved to the file.
+        d.setRegexpTimeoutMs(1000);
+        
+        j.configRoundtrip();
+        
+        d.load();
+        assertEquals(1000, d.getRegexpTimeoutMs());
+    }
 }


### PR DESCRIPTION
[JENKINS-24903](https://issues.jenkins-ci.org/browse/JENKINS-24903)

Some regular expressions can cause catastrophic backtracking.
Malicious users can configure those regular expressions in naginator plugin and and harm Jenkins.

This request adds a feature to aborts regular expressions running too long time.