### PR TITLE
[JENKINS-21241] NAGINATOR_COUNT, NAGINATOR_MAXCOUNT, NAGINATOR_BUILD_NUMBER

### DIFF
--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorAction.java
@@ -38,7 +38,7 @@ public class NaginatorAction implements BuildBadgeAction {
      * @since 1.17
      */
     public NaginatorAction(@CheckForNull Run<?, ?> parentBuild, int retryCount, int maxRetryCount) {
-        this.parentBuildNumber = (parentBuild != null)?parentBuild.getNumber():null;
+        this.parentBuildNumber = (parentBuild != null) ? parentBuild.getNumber() : null;
         this.retryCount = retryCount;
         this.maxRetryCount = maxRetryCount;
     }

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorAction.java
@@ -1,13 +1,17 @@
 package com.chikli.hudson.plugin.naginator;
 
-import hudson.model.Action;
+import javax.annotation.CheckForNull;
+
 import hudson.model.BuildBadgeAction;
+import hudson.model.Run;
 
 /**
  * @author: <a hef="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class NaginatorAction implements BuildBadgeAction {
     private final int retryCount;
+    private final int maxRetryCount;
+    private final Integer parentBuildNumber;
 
     /**
      * @deprecated use {@link NaginatorAction#NaginatorAction(int)}
@@ -20,9 +24,23 @@ public class NaginatorAction implements BuildBadgeAction {
     /**
      * @param retryCount the number of retry this build is rescheduled for.
      * @since 1.16
+     * @deprecated use {@link #NaginatorAction(Run, int, int)} instead.
      */
+    @Deprecated
     public NaginatorAction(int retryCount) {
+        this(null, retryCount, 0);
+    }
+
+    /**
+     * @param parentBuild the build to retry.
+     * @param retryCount the number of retry this build is rescheduled for.
+     * @param maxRetryCount the maximum number to retry. Can be 0 for indeterminable cases.
+     * @since 1.17
+     */
+    public NaginatorAction(@CheckForNull Run<?, ?> parentBuild, int retryCount, int maxRetryCount) {
+        this.parentBuildNumber = (parentBuild != null)?parentBuild.getNumber():null;
         this.retryCount = retryCount;
+        this.maxRetryCount = maxRetryCount;
     }
 
     public String getIconFileName() {
@@ -47,5 +65,32 @@ public class NaginatorAction implements BuildBadgeAction {
      */
     public int getRetryCount() {
         return retryCount;
+    }
+
+    /**
+     * Returns the maximum number to reschedule.
+     * This may be <code>0</code> for builds rescheduled with
+     * older versions of naginator-plugin
+     * for cases that the build is rescheduled manually,
+     * or for cases the maximum number is indeterminable.
+     * 
+     * @return the maximum number to retry.
+     * @since 1.17
+     */
+    public int getMaxRetryCount() {
+        return maxRetryCount;
+    }
+
+    /**
+     * Returns the maximum number to reschedule.
+     * This may be <code>null</code> for builds rescheduled with
+     * older versions of naginator-plugin
+     * 
+     * @return the build number of the build to reschedule.
+     * @since 1.17
+     */
+    @CheckForNull
+    public Integer getParentBuildNumber() {
+        return parentBuildNumber;
     }
 }

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorMatrixAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorMatrixAction.java
@@ -1,8 +1,12 @@
 package com.chikli.hudson.plugin.naginator;
 
 import hudson.matrix.Combination;
+import hudson.model.Run;
+
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.annotation.CheckForNull;
 
 /**
  * This is an extention for the NaginatorAction class which used to store the
@@ -23,9 +27,21 @@ public class NaginatorMatrixAction extends NaginatorAction {
     /**
      * @param retryCount the number of retry this build is rescheduled for.
      * @since 1.16
+     * @deprecated use {@link #NaginatorMatrixAction(Run, int, int)} instead.
      */
+    @Deprecated
     public NaginatorMatrixAction(int retryCount) {
-        super(retryCount);
+        this(null, retryCount, 0);
+    }
+    
+    /**
+     * @param parentBuild the build to be rescheduled.
+     * @param retryCount the number of retry this build is rescheduled for.
+     * @param maxRetryCount the maximum number to retry. Can be 0 for indeterminable cases.
+     * @since 1.17
+     */
+    public NaginatorMatrixAction(@CheckForNull Run<?, ?> parentBuild, int retryCount, int maxRetryCount) {
+        super(parentBuild, retryCount, maxRetryCount);
         this.combsToRerun = new ArrayList<Combination>();
     }
     

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorRetryAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorRetryAction.java
@@ -49,12 +49,12 @@ public class NaginatorRetryAction implements Action {
 
     public void doIndex(StaplerResponse res, @AncestorInPath AbstractBuild build) throws IOException {
         build.getACL().checkPermission(Item.BUILD);
-        NaginatorRetryAction.scheduleBuild(build, 0, NaginatorListener.calculateRetryCount(build));
+        NaginatorRetryAction.scheduleBuild(build, 0, NaginatorListener.calculateRetryCount(build), 0);
         res.sendRedirect2(build.getUpUrl());
     }
 
-    static boolean scheduleBuild(final AbstractBuild<?, ?> build, final int delay, int retryCount) {
-        return scheduleBuild(build, delay, new NaginatorAction(retryCount));
+    static boolean scheduleBuild(final AbstractBuild<?, ?> build, final int delay, int retryCount, int maxRetryCount) {
+        return scheduleBuild(build, delay, new NaginatorAction(build, retryCount, maxRetryCount));
     }
 
     static boolean scheduleBuild(final AbstractBuild<?, ?> build, final int delay, final NaginatorAction action) {

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/help.html
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/help.html
@@ -3,4 +3,14 @@
     <p>
     Note: immediate rescheduling of failed builds, combined with publishers such as e-mail or IM, will flood the
     recipients. Take care to configure a suitable delay between builds or limit the maximum retries.
+    <p>
+    Following variables are defined for rescheduled builds.
+    <dl>
+      <dt>NAGINATOR_COUNT</dt>
+        <dd>How many times the build was rescheduled.</dd>
+      <dt>NAGINATOR_MAXCOUNT</dt>
+        <dd>How many times the build can be rescheduled. This can be 0 if manually rescheduled.</dd>
+      <dt>NAGINATOR_BUILD_NUMBER</dt>
+        <dd>The build number of the failed build causing the reschedule.</dd>
+    </dl>
 </div>


### PR DESCRIPTION
[JENKINS-21241](https://issues.jenkins-ci.org/browse/JENKINS-21241)

Introduced following variables for rescheduled builds
* NAGINATOR_COUNT
* NAGINATOR_MAXCOUNT
* NAGINATOR_BUILD_NUMBER

Feature notes:
* They are defined only for builds triggered by naginator.
* The behavior is undefined if multiple builds are merged (e.g. build A and build B is rescheduled at the same time and they are merged to one build C).

Implementation notes:
* `NaginatorAction` now holds a maximum retrying count and a parent build number.
* I tried implement it with `EnvironmentContributingAction` at first, but didn't work well for matrix projects.

![variables](https://cloud.githubusercontent.com/assets/3115961/12534315/4e33c2c6-c296-11e5-8900-290eb9046d58.jpg)
