### PR TITLE
NaginatorPublisher: Renamed isCheckRegexp to getCheckRegexp.

### DIFF
--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisher.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisher.java
@@ -108,8 +108,8 @@ public class NaginatorPublisher extends Notifier {
     public boolean isRerunMatrixPart() {
         return rerunMatrixPart;
     }
-    
-    public boolean isCheckRegexp() {
+
+    public boolean getCheckRegexp() {
         return checkRegexp;
     }
 

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisherScheduleAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisherScheduleAction.java
@@ -43,7 +43,7 @@ public class NaginatorPublisherScheduleAction extends NaginatorScheduleAction {
         this.regexpForRerun = publisher.getRegexpForRerun();
         this.rerunIfUnstable = publisher.isRerunIfUnstable();
         this.regexpForMatrixParent = publisher.isRegexpForMatrixParent();
-        this.checkRegexp = publisher.isCheckRegexp();
+        this.checkRegexp = publisher.getCheckRegexp();
     }
     
     @CheckForNull

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorPublisherTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorPublisherTest.java
@@ -315,7 +315,7 @@ public class NaginatorPublisherTest {
                 naginator.getRegexpForRerun(),
                 naginator.isRerunIfUnstable(),
                 naginator.isRerunMatrixPart(),
-                naginator.isCheckRegexp(),
+                naginator.getCheckRegexp(),
                 false,  // regexpForMatrixParent (not preserved)
                 naginator.getMaxSchedule(),
                 naginator.getDelay()


### PR DESCRIPTION
I've found a problem since version 1.16

Since 1.16 the regex-Check does not work in combination with checking Matrix-Child-Builds.

As seen in https://wiki.jenkins-ci.org/display/JENKINS/Basic+guide+to+Jelly+usage+in+Jenkins we either need a public checkRegexp field or a getCheckRegexp() function in the NaginatorPublisher class to correctly pass the parameter from the config.jelly

I've provided a fix for that, tho I skipped the tests run using maven in this step. I would appreciate if you could turn this into the next version of the plugin to fix this problem.