### PR TITLE
[JENKINS-32822] Displays the checkbox when the publisher is newly added.

### DIFF
--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisher.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisher.java
@@ -235,15 +235,9 @@ public class NaginatorPublisher extends Notifier {
         
         /**
          * @return true if the current request is for a matrix project.
-         * @since 1.16
          */
-        public boolean isMatrixProject() {
-            StaplerRequest req = Stapler.getCurrentRequest();
-            if (req == null) {
-                return false;
-            }
-            Job<?, ?> job = req.findAncestorObject(Job.class);
-            return (job instanceof MatrixProject);
+        public boolean isMatrixProject(Object it) {
+            return (it instanceof MatrixProject);
         }
     }
 

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/config.jelly
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/config.jelly
@@ -22,7 +22,7 @@
             <f:entry title="${%Regular expression to search for}" field="regexpForRerun">
                 <f:textbox />
             </f:entry>
-            <j:if test="${descriptor.matrixProject}">
+            <j:if test="${descriptor.isMatrixProject(it)}">
                 <f:entry title="${%Test regular expression for the matrix parent}" field="regexpForMatrixParent">
                     <f:checkbox />
                 </f:entry>


### PR DESCRIPTION
[JENKINS-32822](https://issues.jenkins-ci.org/browse/JENKINS-32822)

"Advanced" > "Only rerun build if regular expression is found in output" > "Test regular expression for the matrix parent" is not displayed when you added "Retry build after failure" in multi-configuration projects.
You have to reopen the configuration page to display and configure that.

This change displays that checkbox initially.

* Before this change

    |                                                | FreeStyle (should not displayed) | Matrix (should displayed) |
    |:-----------------------------------------------|:--------------------------------:|:-------------------------:|
    | Add                                            | OK                               | **NG**                    |
    | Reopen the configuration                       | OK                               | OK                        |
    | Add with Flexible Publish                      | OK                               | **NG**                    |
    | Reopen the configuration with Flexible Publish | OK                               | OK                        |

* After this change

    |                                                | FreeStyle (should not displayed) | Matrix (should displayed) |
    |:-----------------------------------------------|:--------------------------------:|:-------------------------:|
    | Add                                            | OK                               | OK                        |
    | Reopen the configuration                       | OK                               | OK                        |
    | Add with Flexible Publish                      | OK                               | OK                        |
    | Reopen the configuration with Flexible Publish | OK                               | OK                        |
