### PR TITLE
[JENKINS-32823] [FIXED JENKINS-32821] Added "When no combinations to rerun" and "How to apply the regular expression to matrix"

### DIFF
--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorListener.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorListener.java
@@ -64,6 +64,19 @@ public class NaginatorListener extends RunListener<AbstractBuild<?,?>> {
                 if (!combsToRerun.isEmpty()) {
                     LOGGER.log(Level.FINE, "schedule matrix rebuild");
                     scheduleMatrixBuild(build, combsToRerun, n, retryCount + 1, action.getMaxSchedule());
+                } else if (build instanceof MatrixBuild && action.isRerunMatrixPart()) {
+                    // No children to rerun
+                    switch (action.getNoChildStrategy()) {
+                    case RerunWhole:
+                        scheduleBuild(build, n, retryCount + 1, action.getMaxSchedule());
+                        break;
+                    case RerunEmpty:
+                        LOGGER.log(Level.FINE, "schedule matrix rebuild");
+                        scheduleMatrixBuild(build, combsToRerun, n, retryCount + 1, action.getMaxSchedule());
+                        break;
+                    case DontRun:
+                        continue;   // confusing, but back to the look for NaginatorScheduleAction
+                    }
                 } else {
                     scheduleBuild(build, n, retryCount + 1, action.getMaxSchedule());
                 }

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisher.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisher.java
@@ -15,12 +15,15 @@ import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
 import net.sf.json.JSONObject;
 
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
 import java.util.logging.Logger;
+
+import javax.annotation.Nonnull;
 
 /**
  * Reschedules a build if the current one fails.
@@ -35,6 +38,7 @@ public class NaginatorPublisher extends Notifier {
     private final boolean rerunMatrixPart;
     private final boolean checkRegexp;
     private final Boolean regexpForMatrixParent;
+    private NoChildStrategy noChildStrategy;    /* almost final */
 
     private ScheduleDelay delay;
 
@@ -107,6 +111,28 @@ public class NaginatorPublisher extends Notifier {
 
     public boolean isRerunMatrixPart() {
         return rerunMatrixPart;
+    }
+    
+    /**
+     * @param noChildStrategy
+     * 
+     * @since 1.17
+     */
+    @DataBoundSetter
+    public void setNoChildStrategy(@Nonnull NoChildStrategy noChildStrategy) {
+        this.noChildStrategy = noChildStrategy;
+    }
+    
+    /**
+     * @return the strategy for no children to rerun for a matrix project.
+     * 
+     * @since 1.17
+     */
+    @Nonnull
+    public NoChildStrategy getNoChildStrategy() {
+        return (noChildStrategy != null)
+                ? noChildStrategy
+                : NoChildStrategy.getDefault();
     }
     
     public boolean isCheckRegexp() {

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisherScheduleAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisherScheduleAction.java
@@ -37,6 +37,7 @@ public class NaginatorPublisherScheduleAction extends NaginatorScheduleAction {
     private final boolean rerunIfUnstable;
     private final boolean checkRegexp;
     private final boolean regexpForMatrixParent;
+    private final NoChildStrategy noChildStrategy;
     
     public NaginatorPublisherScheduleAction(NaginatorPublisher publisher) {
         super(publisher.getMaxSchedule(), publisher.getDelay(), publisher.isRerunMatrixPart());
@@ -44,6 +45,7 @@ public class NaginatorPublisherScheduleAction extends NaginatorScheduleAction {
         this.rerunIfUnstable = publisher.isRerunIfUnstable();
         this.regexpForMatrixParent = publisher.isRegexpForMatrixParent();
         this.checkRegexp = publisher.isCheckRegexp();
+        this.noChildStrategy = publisher.getNoChildStrategy();
     }
     
     @CheckForNull
@@ -229,5 +231,13 @@ public class NaginatorPublisherScheduleAction extends NaginatorScheduleAction {
                 reader.close();
             }
         }
+    }
+    
+    @Override
+    @Nonnull
+    public NoChildStrategy getNoChildStrategy() {
+        return (noChildStrategy != null)
+                ? noChildStrategy
+                : NoChildStrategy.getDefault();
     }
 }

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorScheduleAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorScheduleAction.java
@@ -122,4 +122,14 @@ public class NaginatorScheduleAction extends InvisibleAction {
     public boolean shouldScheduleForMatrixRun(@Nonnull MatrixRun run, @Nonnull TaskListener listener) {
         return true;
     }
+    
+    /**
+     * @return how to do when no children to rerun for a matrix project.
+     * 
+     * @since 1.17
+     */
+    @Nonnull
+    public NoChildStrategy getNoChildStrategy() {
+        return NoChildStrategy.getDefault();
+    }
 }

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NoChildStrategy.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NoChildStrategy.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2016 IKEDA Yasuyuki
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.chikli.hudson.plugin.naginator;
+
+import javax.annotation.Nonnull;
+
+import org.jvnet.localizer.Localizable;
+
+/**
+ * The strategy for no children to rerun.
+ * 
+ * @since 1.17
+ */
+public enum NoChildStrategy {
+    RerunWhole(Messages._NoChildStrategy_RerunWhole_DisplayName()),
+    RerunEmpty(Messages._NoChildStrategy_RerunEmpty_DisplayName()),
+    DontRun(Messages._NoChildStrategy_DontRerun_DisplayName()),
+    ;
+    private final Localizable displayName;
+    
+    private NoChildStrategy(Localizable displayName) {
+        this.displayName = displayName;
+    }
+    
+    public String getDisplayName() {
+        return displayName.toString();
+    }
+    
+    @Nonnull
+    public static NoChildStrategy getDefault() {
+        return RerunWhole;
+    }
+}

--- a/src/main/java/com/chikli/hudson/plugin/naginator/RegexpForMatrixStrategy.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/RegexpForMatrixStrategy.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2016 IKEDA Yasuyuki
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.chikli.hudson.plugin.naginator;
+
+import javax.annotation.Nonnull;
+
+import org.jvnet.localizer.Localizable;
+
+/**
+ * How to apply regexp to matrix builds.
+ */
+public enum RegexpForMatrixStrategy {
+    TestChildrenRetriggerAll(Messages._RegexpForMatrixStrategy_TestChildrenRetriggerAll()),
+    TestChildrenRetriggerMatched(Messages._RegexpForMatrixStrategy_TestChildrenRetriggerMatched()),
+    TestParent(Messages._RegexpForMatrixStrategy_TestParent()),
+    ;
+    private final Localizable displayName;
+    
+    private RegexpForMatrixStrategy(Localizable displayName) {
+        this.displayName = displayName;
+    }
+    
+    public String getDisplayName() {
+        return displayName.toString();
+    }
+    
+    @Nonnull
+    public static RegexpForMatrixStrategy getDefault() {
+        return TestChildrenRetriggerAll;
+    }
+}

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/Messages.properties
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/Messages.properties
@@ -1,4 +1,9 @@
 NaginatorCause.Description=Started by Naginator after build {0} failure
+RegexpForMatrixStrategy.TestChildrenRetriggerAll=Test failed matrix parts, and retrigger all
+RegexpForMatrixStrategy.TestChildrenRetriggerMatched=Test failed matrix parts, and retrigger only matched parts
+RegexpForMatrixStrategy.TestParent=Test the parent build
 NoChildStrategy.RerunWhole.DisplayName=Rerun the matrix with all combinations
 NoChildStrategy.RerunEmpty.DisplayName=Rerun the matrix with no combinations
 NoChildStrategy.DontRerun.DisplayName=Don''t rerun
+NaginatorPublisher.RegexpForMatrixStrategy.RerunMatrixPartShouldBeEnabled=You need to enable "Rerun build only for failed parts on the matrix" to use this strategy.
+

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/Messages.properties
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/Messages.properties
@@ -1,2 +1,4 @@
 NaginatorCause.Description=Started by Naginator after build {0} failure
-
+NoChildStrategy.RerunWhole.DisplayName=Rerun the matrix with all combinations
+NoChildStrategy.RerunEmpty.DisplayName=Rerun the matrix with no combinations
+NoChildStrategy.DontRerun.DisplayName=Don''t rerun

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/config.jelly
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/config.jelly
@@ -3,9 +3,11 @@
         <f:checkbox />
     </f:entry>
 
-    <f:entry title="Rerun build only for failed parts on the matrix" field="rerunMatrixPart">
-        <f:checkbox />
-    </f:entry>
+    <j:if test="${descriptor.isMatrixProject(it)}">
+        <f:entry title="Rerun build only for failed parts on the matrix" field="rerunMatrixPart">
+            <f:checkbox />
+        </f:entry>
+    </j:if>
 
     <f:entry title="${%Delay before retrying build}">
         <j:invokeStatic var="delays" className="com.chikli.hudson.plugin.naginator.ScheduleDelay" method="all"/>
@@ -17,6 +19,11 @@
     </f:entry>
 
     <f:advanced>
+        <j:if test="${descriptor.isMatrixProject(it)}">
+            <f:entry title="${%When no combinations to rerun}" field="noChildStrategy">
+                <f:enum>${it.displayName}</f:enum>
+            </f:entry>
+        </j:if>
         <f:optionalBlock field="checkRegexp" inline="true"
                  title="${%Only rerun build if regular expression is found in output}">
             <f:entry title="${%Regular expression to search for}" field="regexpForRerun">

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/config.jelly
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/config.jelly
@@ -30,8 +30,9 @@
                 <f:textbox />
             </f:entry>
             <j:if test="${descriptor.isMatrixProject(it)}">
-                <f:entry title="${%Test regular expression for the matrix parent}" field="regexpForMatrixParent">
-                    <f:checkbox />
+                <f:entry title="${%How to apply the regular expression to matrix}" field="regexpForMatrixStrategy">
+                    <!-- unfortunatelly, f:enum doesn't support doCheckXxxx -->
+                    <f:select />
                 </f:entry>
             </j:if>
         </f:optionalBlock>

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/help-noChildStrategy.html
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/help-noChildStrategy.html
@@ -1,0 +1,12 @@
+<div>
+How to rerun the build if no combinations to rerun.
+This configuration takes effect only when you check "Rerun build only for failed parts on the matrix".
+<dl>
+  <dt>Rerun the matrix with all combinations</dt>
+    <dd>Reruns whole the matrix. This is useful if you want always rerun something.</dd>
+  <dt>Rerun the matrix with no combinations</dt>
+    <dd>Reruns the matrix with no children. This is useful if you want rerun only aggregation processes. Some processes may fail if no children.</dd>
+  <dt>Don't rerun</dt>
+    <dd>Doesn't rerun the matrix. This is useful especially when used with the regular expressions.</dd>
+</dl>
+</div>

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/help-rerunMatrixPart.html
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/help-rerunMatrixPart.html
@@ -1,0 +1,5 @@
+<div>
+Applicable only to multi-configuration projects.
+Reruns only failed axes combinations.
+If not checked, always reruns all the combinations.
+</div>

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorPublisherTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorPublisherTest.java
@@ -284,12 +284,18 @@ public class NaginatorPublisherTest {
                 1,      // maxSchedule
                 new FixedDelay(0)
         );
+        naginator.setNoChildStrategy(NoChildStrategy.RerunEmpty);
         
         p.getPublishersList().add(naginator);
         
         j.configRoundtrip(p);
         
         j.assertEqualDataBoundBeans(naginator, p.getPublishersList().get(NaginatorPublisher.class));
+        // assertEqualDataBoundBeans doesn't work for DataBoundSetter fields.
+        assertEquals(
+                naginator.getNoChildStrategy(),
+                p.getPublishersList().get(NaginatorPublisher.class).getNoChildStrategy()
+        );
     }
     
     
@@ -311,15 +317,17 @@ public class NaginatorPublisherTest {
                 1,      // maxSchedule
                 new FixedDelay(0)
         );
+        naginator.setNoChildStrategy(NoChildStrategy.RerunEmpty);
         NaginatorPublisher expected = new NaginatorPublisher(
                 naginator.getRegexpForRerun(),
                 naginator.isRerunIfUnstable(),
-                naginator.isRerunMatrixPart(),
+                false,  // retunMatrixPart (not preserved)
                 naginator.isCheckRegexp(),
                 false,  // regexpForMatrixParent (not preserved)
                 naginator.getMaxSchedule(),
                 naginator.getDelay()
         );
+        naginator.setNoChildStrategy(NoChildStrategy.getDefault());     // not preserved
         
         p.getPublishersList().add(naginator);
         
@@ -327,6 +335,11 @@ public class NaginatorPublisherTest {
         
         assertFalse(p.getPublishersList().get(NaginatorPublisher.class).isRegexpForMatrixParent());
         j.assertEqualDataBoundBeans(expected, p.getPublishersList().get(NaginatorPublisher.class));
+        // assertEqualDataBoundBeans doesn't work for DataBoundSetter fields.
+        assertEquals(
+                expected.getNoChildStrategy(),
+                p.getPublishersList().get(NaginatorPublisher.class).getNoChildStrategy()
+        );
     }
     
     @Test

--- a/src/test/java/com/chikli/hudson/plugin/naginator/testutils/MyBuilder.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/testutils/MyBuilder.java
@@ -1,5 +1,7 @@
 package com.chikli.hudson.plugin.naginator.testutils;
 
+import groovy.lang.Binding;
+import groovy.lang.GroovyShell;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -18,18 +20,29 @@ public final class MyBuilder extends Builder {
     private final String text;
     private final Result result;
     private final int duration;
+    private final String successCondition;
 
     public MyBuilder(String text, Result result) {
         super();
         this.text = text;
         this.result = result;
         this.duration = 0;
+        this.successCondition = null;
     }
 
     public MyBuilder(String text, Result result, int duration) {
         this.text = text;
         this.result = result;
         this.duration = duration;
+        this.successCondition = null;
+    }
+
+    public MyBuilder(String text, String successCondition) {
+        super();
+        this.text = text;
+        this.result = Result.SUCCESS;
+        this.duration = 0;
+        this.successCondition = successCondition;
     }
 
     @Override
@@ -40,6 +53,11 @@ public final class MyBuilder extends Builder {
 
         listener.getLogger().println(build.getEnvironment(listener).expand(text));
         build.setResult(result);
+        if (successCondition != null) {
+            Binding binding = new Binding(build.getEnvironment(listener));
+            GroovyShell shell = new GroovyShell(binding);
+            return (Boolean)shell.evaluate(successCondition);
+        }
         return true;
     }
 


### PR DESCRIPTION
[JENKINS-32823](https://issues.jenkins-ci.org/browse/JENKINS-32823)

When "Rerun build only for failed parts on the matrix" is checked but no children to rerun, naginator-plugin reruns whole the matrix.
This happens following cases:
* An aggregation process of the matrix is failed.
* The regular expression for logs doesn't match any children.

I introduced a new configuration "When no combinations to rerun" in the "Advanced" section.
* Rerun the matrix with all combinations
    * Behaves as before (as described above)
    * Default settings.
* Rerun the matrix with no combinations
    * Reruns only the parent of the matrix. (amazingly, it works)
* Don't rerun
    * Don't rerun a new build.

Though I think almost all users expect "Don't rerun" as the default configuration, I finally decided to have "Rerun the matrix with all combinations" default as:
* For the backward compatibility.
* I believe this feature is often used with the regular expression feature,  and the field for the regular expression feature is also in "Advanced" section. Users don't miss this feature.

Screen shots:
* For multi-configuration projects (Note that "When no combinations to rerun" in the "Advanced" section)
![newfield](https://cloud.githubusercontent.com/assets/3115961/13194215/74eefade-d7cc-11e5-9ac1-8136e4f23cc3.png)
* For non multi-configuration projects: fields applicable only to multi-configuration projects are not displayed
![freestyle](https://cloud.githubusercontent.com/assets/3115961/13194217/889ab99c-d7cc-11e5-95e6-01a78edd2982.png)
