### PR TITLE
[JENKINS-34900] Fix NPE when triggering single Maven module.

### DIFF
--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorListener.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorListener.java
@@ -91,7 +91,13 @@ public class NaginatorListener extends RunListener<AbstractBuild<?,?>> {
     public Environment setUpEnvironment(@SuppressWarnings("rawtypes") AbstractBuild build, Launcher launcher, BuildListener listener)
             throws IOException, InterruptedException, RunnerAbortedException
     {
-        final NaginatorAction action = build.getRootBuild().getAction(NaginatorAction.class);
+        AbstractBuild<?, ?> rootBuild = build.getRootBuild();
+        if (rootBuild == null) {
+            // getRootBuild() should not be null, 
+            // but some builds irregularly returns null. 
+            rootBuild = build;
+        }
+        final NaginatorAction action = rootBuild.getAction(NaginatorAction.class);
         if (action == null) {
             return null;
         }


### PR DESCRIPTION
[JENKINS-34900](https://issues.jenkins-ci.org/browse/JENKINS-34900)

Maven-plugin allows trigger a single Maven module for a maven project.
In that case, `MavenBuild#getRootBuild` returns `null`.