### PR TITLE
[JENKINS-36438] Fixed NPE for "Retry" in pipeline builds.

### DIFF
--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorActionFactory.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorActionFactory.java
@@ -1,7 +1,11 @@
 package com.chikli.hudson.plugin.naginator;
 
 import hudson.Extension;
-import hudson.model.*;
+import hudson.model.AbstractBuild;
+import hudson.model.Action;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TransientBuildActionFactory;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -16,7 +20,7 @@ public class NaginatorActionFactory extends TransientBuildActionFactory {
     @Override
     public Collection<? extends Action> createFor(Run target) {
         Result result = target.getResult();
-        if (result != null && result.isWorseThan(Result.SUCCESS)) {
+        if ((target instanceof AbstractBuild) && result != null && result.isWorseThan(Result.SUCCESS)) {
             NaginatorOptOutProperty p = (NaginatorOptOutProperty) target.getParent().getProperty(NaginatorOptOutProperty.class);
             if (p == null || !p.isOptOut()) return Collections.singleton(new NaginatorRetryAction());
         }


### PR DESCRIPTION
[JENKINS-36438](https://issues.jenkins-ci.org/browse/JENKINS-36438)

"Retry" is displayed also for pipeline builds.
When you click the link, it causes NPE.
This is caused for #22.

Anyway, naginator-plugin doesn't support pipelines for now.
I decided not to display "Retry" for pipeline builds as fix for JENKINS-36438.

I think naginator-plugin can support pipelines but it requires more considerations and changes, and I created [JENKINS-37076](https://issues.jenkins-ci.org/browse/JENKINS-37076) for that..
