### PR TITLE
Make Matrix Project plugin dependency explicit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>1.554</jenkins.version>
+    <jenkins.version>1.565</jenkins.version>
     <java.level>6</java.level>
   </properties>
   
@@ -75,6 +75,11 @@
     </pluginRepositories>
     
     <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.0</version>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>

--- a/src/main/java/com/chikli/hudson/plugin/naginator/ScheduleDelay.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/ScheduleDelay.java
@@ -14,7 +14,11 @@ public abstract class ScheduleDelay extends AbstractDescribableImpl<ScheduleDela
     public abstract int computeScheduleDelay(AbstractBuild failedBuild);
 
     public static DescriptorExtensionList<ScheduleDelay, Descriptor<ScheduleDelay>> all() {
-        return Jenkins.getInstance().getDescriptorList(ScheduleDelay.class);
+        Jenkins j = Jenkins.getInstance();
+        if (j == null) {
+            return null;
+        }
+        return j.getDescriptorList(ScheduleDelay.class);
     }
 
     public static abstract class ScheduleDelayDescriptor extends Descriptor<ScheduleDelay> {


### PR DESCRIPTION
Otherwise not having the Matrix Plugin enabled/installed will still allow this plugin to load and result in errors.

    Jan 16, 2017 11:52:56 PM hudson.ExtensionFinder$Sezpoz scout
    WARNING: Failed to scout com.chikli.hudson.plugin.naginator.NaginatorMatrixBuildListner
    java.lang.InstantiationException: java.lang.NoClassDefFoundError: hudson/matrix/listeners/MatrixBuildListener
