### PR TITLE
Make matrix-project optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   </description>
   <artifactId>naginator</artifactId>
   <packaging>hpi</packaging>
-  <version>1.17.3-SNAPSHOT</version>
+  <version>1.18.0-SNAPSHOT</version>
   <url>
     http://wiki.jenkins-ci.org/display/JENKINS/Naginator+Plugin
   </url>
@@ -79,6 +79,7 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
             <version>1.0</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/main/java/com/chikli/hudson/plugin/naginator/MatrixSupportUtility.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/MatrixSupportUtility.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 IKEDA Yasuyuki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.chikli.hudson.plugin.naginator;
+
+import javax.annotation.Nonnull;
+
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixProject;
+import hudson.matrix.MatrixRun;
+import hudson.model.Job;
+import hudson.model.Run;
+import jenkins.model.Jenkins;
+
+/**
+ * Utility to support matrix-project plugin.
+ *
+ * @since 1.18.0
+ */
+public class MatrixSupportUtility {
+    /**
+     * @return true if matrix-project-plugin is installed.
+     */
+    public static boolean isMatrixInstalled() {
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins == null) {
+            return false;
+        }
+        return (jenkins.getPlugin("matrix-project") != null);
+    }
+
+    /**
+     * @param run {@link Run} to test.
+     * @return true if {@code run} is a {@link MatrixBuild}
+     */
+    public static boolean isMatrixBuild(@Nonnull Run<?, ?> run) {
+        if (!isMatrixInstalled()) {
+            return false;
+        }
+        return (run instanceof MatrixBuild);
+    }
+
+    /**
+     * @param run {@link Run} to test.
+     * @return true if {@code run} is a {@link MatrixRun}
+     */
+    public static boolean isMatrixRun(@Nonnull Run<?, ?> run) {
+        if (!isMatrixInstalled()) {
+            return false;
+        }
+        return (run instanceof MatrixRun);
+    }
+
+    /**
+     * @param job {@link Job} to test.
+     * @return true if {@code job} is a {@link MatrixProject}
+     */
+    public static boolean isMatrixProject(@Nonnull Job<?, ?> job) {
+        if (!isMatrixInstalled()) {
+            return false;
+        }
+        return (job instanceof MatrixProject);
+    }
+}

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorMatrixBuildListner.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorMatrixBuildListner.java
@@ -4,15 +4,13 @@ import hudson.Extension;
 import hudson.matrix.MatrixBuild;
 import hudson.matrix.MatrixConfiguration;
 import hudson.matrix.listeners.MatrixBuildListener;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 
 /**
  *
  * @author galunto
  */
-@Extension
+@Extension(optional=true)
 public class NaginatorMatrixBuildListner extends MatrixBuildListener {
     
     /*

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisher.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisher.java
@@ -4,11 +4,10 @@ import hudson.Extension;
 import hudson.Launcher;
 import hudson.matrix.MatrixRun;
 import hudson.matrix.MatrixBuild;
-import hudson.matrix.MatrixProject;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
-import hudson.model.Job;
 import hudson.model.BuildListener;
+import hudson.model.Job;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
@@ -19,7 +18,6 @@ import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -198,7 +196,7 @@ public class NaginatorPublisher extends Notifier {
 
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-        if (build instanceof MatrixRun) {
+        if (MatrixSupportUtility.isMatrixRun(build)) {
             if (
                     getRegexpForMatrixStrategy() == RegexpForMatrixStrategy.TestChildrenRetriggerMatched
                     && !isRerunMatrixPart()
@@ -302,7 +300,11 @@ public class NaginatorPublisher extends Notifier {
          * @return true if the current request is for a matrix project.
          */
         public boolean isMatrixProject(Object it) {
-            return (it instanceof MatrixProject);
+            return (
+                it != null
+                && (it instanceof Job)
+                && MatrixSupportUtility.isMatrixProject((Job<?, ?>)it)
+            );
         }
         
         public FormValidation doCheckRegexpForMatrixStrategy(

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisherScheduleAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisherScheduleAction.java
@@ -105,7 +105,7 @@ public class NaginatorPublisherScheduleAction extends NaginatorScheduleAction {
         
         // If we're supposed to check for a regular expression in the build output before
         // scheduling a new build, do so.
-        if (isCheckRegexp() && (!(run instanceof MatrixBuild) || getRegexpForMatrixStrategy() == RegexpForMatrixStrategy.TestParent)) {
+        if (isCheckRegexp() && (!MatrixSupportUtility.isMatrixBuild(run) || getRegexpForMatrixStrategy() == RegexpForMatrixStrategy.TestParent)) {
             LOGGER.log(Level.FINEST, "Got checkRegexp == true");
             
             if (!testRegexp(run, listener)) {
@@ -113,7 +113,7 @@ public class NaginatorPublisherScheduleAction extends NaginatorScheduleAction {
             }
         } else if (
                 isCheckRegexp()
-                && (run instanceof MatrixBuild)
+                && MatrixSupportUtility.isMatrixBuild(run)
                 && getRegexpForMatrixStrategy() == RegexpForMatrixStrategy.TestChildrenRetriggerAll
         ) {
             // check should be performed for child builds here.


### PR DESCRIPTION
#37 have naginator-plugin depends on matrix-project
(matrix-project is split from Jenkins core since Jenkins 1.561).

This change make naginator-plugin installable without matrix-project.
