### PR TITLE
Revert "Make Matrix Project plugin dependency explicit"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>1.565</jenkins.version>
+    <jenkins.version>1.554</jenkins.version>
     <java.level>6</java.level>
   </properties>
   
@@ -75,11 +75,6 @@
     </pluginRepositories>
     
     <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>matrix-project</artifactId>
-            <version>1.0</version>
-        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>

--- a/src/main/java/com/chikli/hudson/plugin/naginator/ScheduleDelay.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/ScheduleDelay.java
@@ -14,11 +14,7 @@ public abstract class ScheduleDelay extends AbstractDescribableImpl<ScheduleDela
     public abstract int computeScheduleDelay(AbstractBuild failedBuild);
 
     public static DescriptorExtensionList<ScheduleDelay, Descriptor<ScheduleDelay>> all() {
-        Jenkins j = Jenkins.getInstance();
-        if (j == null) {
-            return null;
-        }
-        return j.getDescriptorList(ScheduleDelay.class);
+        return Jenkins.getInstance().getDescriptorList(ScheduleDelay.class);
     }
 
     public static abstract class ScheduleDelayDescriptor extends Descriptor<ScheduleDelay> {


### PR DESCRIPTION
Reverts jenkinsci/naginator-plugin#37

Jenkins core injects automatic dependencies to plugins depending on old Jenkins core:
https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/ClassicPluginStrategy.java
(See DETACHED_LIST)
I found this feature today...

And it's unnecessary to make naginator-plugin explicitly depending on matrix-project.
