### PR TITLE
added the ability to override maxSchedule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,11 @@
+<?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <version>2.9</version>
   </parent>
-  
   <name>Naginator</name>
   <description>
     Naginator is a plugin for Hudson that schedules a new build
@@ -15,30 +14,41 @@
   </description>
   <artifactId>naginator</artifactId>
   <packaging>hpi</packaging>
-  <version>1.17.3-SNAPSHOT</version>
+  <version>1.18.0-SNAPSHOT</version>
   <url>
     http://wiki.jenkins-ci.org/display/JENKINS/Naginator+Plugin
   </url>
-
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/naginator-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/naginator-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/naginator-plugin</url>
     <tag>HEAD</tag>
   </scm>
-
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <commons-exec.version>1.3</commons-exec.version>
+    <commons-io.version>2.5</commons-io.version>
+    <commons-lang.version>2.6</commons-lang.version>
+    <commons-collections4.version>4.0</commons-collections4.version>
+    <hamcrest-all.version>1.3</hamcrest-all.version>
+    <hamcrest-date.version>2.0.4</hamcrest-date.version>
+    <junit.version>4.12</junit.version>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
+    <maven-surefire-plugin.version>2.20</maven-surefire-plugin.version>
     <jenkins.version>1.554</jenkins.version>
     <java.level>6</java.level>
+    <java.version>1.6</java.version>
+    <!-- java.level 7 and 8 is supported -->
   </properties>
-  
   <licenses>
     <license>
       <name>MIT license</name>
       <comments>All source code is under the MIT license.</comments>
     </license>
   </licenses>
-  
   <developers>
     <developer>
       <id>abayer</id>
@@ -58,62 +68,106 @@
       <email>tomer4@gmail.com</email>
       <timezone>+2</timezone>
     </developer>
+    <developer>
+      <name>Serguei Kouzmine</name>
+      <email>kouzmine_serguei@yahoo.com</email>
+      <organization/>
+      <organizationUrl>https://github.com/sergueik</organizationUrl>
+      <timezone>-5</timezone>
+    </developer>
   </developers>
-
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-    
-    <dependencies>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>matrix-auth</artifactId>
-            <version>1.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>maven-plugin</artifactId>
-            <version>2.1</version>
-            <scope>test</scope>
-            <exclusions>
-              <!--
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>spring</id>
+      <url>http://repo.spring.io/plugins-release/</url>
+    </pluginRepository>
+  </pluginRepositories>
+  <dependencies>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>${hamcrest-all.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.jcabi</groupId>
+      <artifactId>jcabi-matchers</artifactId>
+      <version>1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.9.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-auth</artifactId>
+      <version>1.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>maven-plugin</artifactId>
+      <version>2.1</version>
+      <scope>test</scope>
+      <exclusions>
+        <!--
                   To pick up http component classes from jenkins-test-harness dependencies
                   in test executions.
               -->
-              <exclusion>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpclient</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpcore</artifactId>
-              </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-test-harness-tools</artifactId>
-            <version>2.0</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-</project>  
-  
-
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-test-harness-tools</artifactId>
+      <version>2.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+        <goals>
+          <goal>compile</goal>
+        </goals>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <encoding>utf-8</encoding>
+          <compilerArgument>-Xlint:all</compilerArgument>
+          <showWarnings>true</showWarnings>
+          <showDeprecation>true</showDeprecation>
+          <!--
+          <compilerArgument>-verbose</compilerArgument>
+          -->
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/main/java/com/chikli/hudson/plugin/naginator/FixedDelay.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/FixedDelay.java
@@ -6,7 +6,7 @@ import hudson.model.AbstractBuild;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
- * @author: <a hef="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ * @author: <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class FixedDelay extends ScheduleDelay {
 

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorAction.java
@@ -6,7 +6,7 @@ import hudson.model.BuildBadgeAction;
 import hudson.model.Run;
 
 /**
- * @author: <a hef="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ * @author: <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class NaginatorAction implements BuildBadgeAction {
     private final int retryCount;

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisher.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisher.java
@@ -21,311 +21,330 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
+
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
 import java.util.logging.Logger;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.lang.Boolean.parseBoolean;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+
 import javax.annotation.Nonnull;
 
-/**
- * Reschedules a build if the current one fails.
- *
- * @author Nayan Hajratwala <nayan@chikli.com>
- */
+@SuppressWarnings("unused")
 public class NaginatorPublisher extends Notifier {
-    public final static long DEFAULT_REGEXP_TIMEOUT_MS = 30000;
-    
-    private final String regexpForRerun;
-    private final boolean rerunIfUnstable;
-    private final boolean rerunMatrixPart;
-    private final boolean checkRegexp;
-    @Deprecated
-    private transient Boolean regexpForMatrixParent;
-    private RegexpForMatrixStrategy regexpForMatrixStrategy;    /* almost final */
-    private NoChildStrategy noChildStrategy;    /* almost final */
+	public final static long DEFAULT_REGEXP_TIMEOUT_MS = 30000;
 
-    private ScheduleDelay delay;
+	private final String regexpForRerun;
+	private final boolean rerunIfUnstable;
+	private final boolean rerunMatrixPart;
+	private final boolean checkRegexp;
+	private final boolean maxScheduleOverrideAllowed;
+	@Deprecated
+	private transient Boolean regexpForMatrixParent;
+	private RegexpForMatrixStrategy regexpForMatrixStrategy; /* almost final */
+	private NoChildStrategy noChildStrategy; /* almost final */
 
-    private int maxSchedule;
+	private ScheduleDelay delay;
 
-    // backward compatible constructor
-    public NaginatorPublisher(String regexpForRerun,
-                              boolean rerunIfUnstable,
-                              boolean checkRegexp) {
-        this(regexpForRerun, rerunIfUnstable, false, checkRegexp, 0, new ProgressiveDelay(5*60, 3*60*60));
-    }
+	private int maxSchedule; // possibly gets overriden after the build run
 
-    /**
-     * constructor.
-     */
-    @DataBoundConstructor
-    public NaginatorPublisher(String regexpForRerun,
-                              boolean rerunIfUnstable,
-                              boolean rerunMatrixPart,
-                              boolean checkRegexp,
-                              int maxSchedule,
-                              ScheduleDelay delay) {
-        this.regexpForRerun = regexpForRerun;
-        this.rerunIfUnstable = rerunIfUnstable;
-        this.rerunMatrixPart = rerunMatrixPart;
-        this.checkRegexp = checkRegexp;
-        this.maxSchedule = maxSchedule;
-        this.delay = delay;
-        setRegexpForMatrixStrategy(RegexpForMatrixStrategy.TestParent); // backward compatibility with < 1.16
-    }
-    
-    /**
-     * @since 1.16
-     * @deprecated use {@link #NaginatorPublisher(String, boolean, boolean, boolean, int, ScheduleDelay)} and other setters
-     */
-    @Deprecated
-    public NaginatorPublisher(String regexpForRerun,
-                              boolean rerunIfUnstable,
-                              boolean rerunMatrixPart,
-                              boolean checkRegexp,
-                              boolean regexpForMatrixParent,
-                              int maxSchedule,
-                              ScheduleDelay delay) {
-        this(regexpForRerun, rerunIfUnstable, rerunMatrixPart, checkRegexp, maxSchedule, delay);
-        setRegexpForMatrixParent(regexpForMatrixParent);
-    }
+	// backward compatible constructor
+	public NaginatorPublisher(String regexpForRerun, boolean rerunIfUnstable,
+			boolean checkRegexp) {
+		this(regexpForRerun, rerunIfUnstable, false, checkRegexp, false, 0,
+				new ProgressiveDelay(5 * 60, 3 * 60 * 60));
+	}
 
-    public Object readResolve() {
-        if (this.delay == null) {
-            // Backward compatibility : progressive 5 minutes up to 3 hours
-            delay = new ProgressiveDelay(5*60, 3*60*60);
-        }
-        if (regexpForMatrixStrategy == null) {
-            if (regexpForMatrixParent != null) {
-                // >= 1.16
-                setRegexpForMatrixParent(regexpForMatrixParent.booleanValue());
-                regexpForMatrixParent = null;
-            } else {
-                // < 1.16
-                setRegexpForMatrixStrategy(RegexpForMatrixStrategy.TestParent);
-            }
-        }
-        return this;
-    }
+	/**
+	 * Constructor
+	 *
+	 * @param regexpForRerun regular expression to scan build log
+	 * @param rerunIfUnstable whether to rerun unstable builds
+	 * @param rerunMatrixPart whether to rerun matrix build
+	 * @param checkRegexp use the regexpForRerun to determine whether to rerun the failing build
+	 * @param maxScheduleOverrideAllowed extract the maxSchedule with the help of the regexpForRerun
+	 * @param maxSchedule maximum number of consecutive reruns
+	 * @param delay delay between reruns
+	 */
 
-    public boolean isRerunIfUnstable() {
-        return rerunIfUnstable;
-    }
+	@DataBoundConstructor
+	public NaginatorPublisher(String regexpForRerun, boolean rerunIfUnstable,
+			boolean rerunMatrixPart, boolean checkRegexp,
+			boolean maxScheduleOverrideAllowed, int maxSchedule,
+			ScheduleDelay delay) {
+		this.regexpForRerun = regexpForRerun;
+		// extract from regexpForRerun
+		// TODO: defer to testRegexp()
+		Pattern pattern = Pattern.compile(this.regexpForRerun);
+		// dummy
+		java.util.regex.Matcher matcher = pattern.matcher("");
+		assertFalse(matcher.find());
 
-    public boolean isRerunMatrixPart() {
-        return rerunMatrixPart;
-    }
-    
-    /**
-     * @param noChildStrategy
-     * 
-     * @since 1.17
-     */
-    @DataBoundSetter
-    public void setNoChildStrategy(@Nonnull NoChildStrategy noChildStrategy) {
-        this.noChildStrategy = noChildStrategy;
-    }
-    
-    /**
-     * @return the strategy for no children to rerun for a matrix project.
-     * 
-     * @since 1.17
-     */
-    @Nonnull
-    public NoChildStrategy getNoChildStrategy() {
-        return (noChildStrategy != null)
-                ? noChildStrategy
-                : NoChildStrategy.getDefault();
-    }
-    
-    public boolean isCheckRegexp() {
-        return checkRegexp;
-    }
+		this.rerunIfUnstable = rerunIfUnstable;
+		this.rerunMatrixPart = rerunMatrixPart;
+		this.checkRegexp = checkRegexp;
+		this.maxSchedule = maxSchedule;
+		this.maxScheduleOverrideAllowed = maxScheduleOverrideAllowed;
+		this.delay = delay;
+		setRegexpForMatrixStrategy(RegexpForMatrixStrategy.TestParent); // backward
+																																		// 1.16
+	}
 
-    /**
-     * Returns whether apply the regexp to the matrix parent instead of matrix children.
-     * 
-     * The default is <code>false</code> for naginator-plugin >= 1.16
-     * though <code>true</code> for configurations upgraded from naginator-plugin < 1.16.
-     * 
-     * @return Returns whether apply the regexp to the matrix parent instead of matrix children
-     * @since 1.16
-     * @deprecated use {@link #getRegexpForMatrixStrategy()}
-     */
-    @Deprecated
-    public boolean isRegexpForMatrixParent() {
-        return (getRegexpForMatrixStrategy() == RegexpForMatrixStrategy.TestParent);
-    }
+	/**
+	 * Constructor
+	 *
+	 * @param regexpForRerun regular expression to scan build log
+	 * @param rerunIfUnstable whether to rerun unstable builds
+	 * @param rerunMatrixPart whether to rerun matrix build
+	 * @param checkRegexp use the regexpForRerun to determine whether to rerun the failing build
+	 * @param regexpForMatrixParent analog of regexpForRerun provided for the parent build
+	 * @param maxScheduleOverrideAllowed extract the maxSchedule with the help of the regexpForRerun
+	 * @param maxSchedule maximum number of consecutive reruns
+	 * @param delay delay between reruns
+	 */
+	@Deprecated
+	public NaginatorPublisher(String regexpForRerun, boolean rerunIfUnstable,
+			boolean rerunMatrixPart, boolean checkRegexp,
+			boolean maxScheduleOverrideAllowed, boolean regexpForMatrixParent,
+			int maxSchedule, ScheduleDelay delay) {
+		this(regexpForRerun, rerunIfUnstable, rerunMatrixPart, checkRegexp,
+				maxScheduleOverrideAllowed, maxSchedule, delay);
+		setRegexpForMatrixParent(regexpForMatrixParent);
+	}
 
-    private void setRegexpForMatrixParent(boolean regexpForMatrixParent) {
-        setRegexpForMatrixStrategy(
-                regexpForMatrixParent
-                ? RegexpForMatrixStrategy.TestParent
-                : RegexpForMatrixStrategy.TestChildrenRetriggerMatched  // compatible with 1.16.
-        );
-    }
+	//
+	public Object readResolve() {
+		if (this.delay == null) {
+			// Backward compatibility : progressive 5 minutes up to 3 hours
+			delay = new ProgressiveDelay(5 * 60, 3 * 60 * 60);
+		}
+		if (regexpForMatrixStrategy == null) {
+			if (regexpForMatrixParent != null) {
+				// >= 1.16
+				setRegexpForMatrixParent(regexpForMatrixParent.booleanValue());
+				regexpForMatrixParent = null;
+			} else {
+				// < 1.16
+				setRegexpForMatrixStrategy(RegexpForMatrixStrategy.TestParent);
+			}
+		}
+		return this;
+	}
 
-    public String getRegexpForRerun() {
-        return regexpForRerun;
-    }
+	public boolean isMaxScheduleOverrideAllowed() {
+		return maxScheduleOverrideAllowed;
+	}
 
-    /**
-     * @param regexpForMatrixStrategy
-     * @since 1.17
-     */
-    @DataBoundSetter
-    public void setRegexpForMatrixStrategy(@Nonnull RegexpForMatrixStrategy regexpForMatrixStrategy) {
-        this.regexpForMatrixStrategy = regexpForMatrixStrategy;
-    }
+	public boolean isRerunIfUnstable() {
+		return rerunIfUnstable;
+	}
 
-    /**
-     * @return how to apply regexp for matrix builds.
-     * @since 1.17
-     */
-    @Nonnull
-    public RegexpForMatrixStrategy getRegexpForMatrixStrategy() {
-        return regexpForMatrixStrategy;
-    }
+	public boolean isRerunMatrixPart() {
+		return rerunMatrixPart;
+	}
 
-    public ScheduleDelay getDelay() {
-        return delay;
-    }
+	// https://www.programcreek.com/java-api-examples/index.php?api=org.kohsuke.stapler.DataBoundSetter
+	@DataBoundSetter
+	public void setNoChildStrategy(@Nonnull NoChildStrategy noChildStrategy) {
+		this.noChildStrategy = noChildStrategy;
+	}
 
-    public int getMaxSchedule() {
-        return maxSchedule;
-    }
+	/**
+	 * @return the strategy for no children to rerun for a matrix project.
+	 *
+	 * @since 1.17
+	 */
+	@Nonnull
+	public NoChildStrategy getNoChildStrategy() {
+		return (noChildStrategy != null) ? noChildStrategy
+				: NoChildStrategy.getDefault();
+	}
 
-    @Override
-    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-        if (build instanceof MatrixRun) {
-            if (
-                    getRegexpForMatrixStrategy() == RegexpForMatrixStrategy.TestChildrenRetriggerMatched
-                    && !isRerunMatrixPart()
-            ) {
-                listener.getLogger().println("[Naginator] Warning: TestChildrenRetriggerMatched doesn't work without rerunMatrixPart");
-            }
-            
-            MatrixBuild parent = ((MatrixRun)build).getParentBuild();
-            if (parent.getAction(NaginatorPublisherScheduleAction.class) == null) {
-                // No strict exclusion is required
-                // as it doesn't matter if the action gets duplicated.
-                parent.addAction(new NaginatorPublisherScheduleAction(this));
-            }
-        } else {
-            build.addAction(new NaginatorPublisherScheduleAction(this));
-        }
-        return true;
-    }
+	public boolean isCheckRegexp() {
+		return checkRegexp;
+	}
 
-    public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.NONE;
-    }
+	@Deprecated
+	public boolean isRegexpForMatrixParent() {
+		return (getRegexpForMatrixStrategy() == RegexpForMatrixStrategy.TestParent);
+	}
 
+	private void setRegexpForMatrixParent(boolean regexpForMatrixParent) {
+		setRegexpForMatrixStrategy(
+				regexpForMatrixParent ? RegexpForMatrixStrategy.TestParent
+						: RegexpForMatrixStrategy.TestChildrenRetriggerMatched // compatible
+																																		// with
+																																		// 1.16.
+		);
+	}
 
-    @Override
-    public DescriptorImpl getDescriptor() {
-        // see Descriptor javadoc for more about what a descriptor is.
-        return (DescriptorImpl) super.getDescriptor();
-    }
+	public String getRegexpForRerun() {
+		return regexpForRerun;
+	}
 
-    @Extension
-    public final static NaginatorListener LISTENER = new NaginatorListener();
+	/**
+	 * Sets the maxSchedule property, initially filled from data bound comstructor e.g. from the matched build log message.
+	 *
+	 * @param value new maxSchedule
+	 * @see getMaxSchedule
+	 */
+	public void setMaxSchedule(int value) {
+		this.maxSchedule = value;
+	}
 
+	@DataBoundSetter
+	public void setRegexpForMatrixStrategy(
+			@Nonnull RegexpForMatrixStrategy regexpForMatrixStrategy) {
+		this.regexpForMatrixStrategy = regexpForMatrixStrategy;
+	}
 
-    /**
-     * Descriptor for {@link NaginatorPublisher}. Used as a singleton.
-     * The class is marked as public so that it can be accessed from views.
-     *
-     * <p>
-     * See <tt>views/hudson/plugins/naginator/NaginatorBuilder/*.jelly</tt>
-     * for the actual HTML fragment for the configuration screen.
-     */
-    @Extension
-    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
-        private long regexpTimeoutMs;
+	@Nonnull
+	public RegexpForMatrixStrategy getRegexpForMatrixStrategy() {
+		return regexpForMatrixStrategy;
+	}
 
-        public DescriptorImpl() {
-            // default value
-            regexpTimeoutMs = DEFAULT_REGEXP_TIMEOUT_MS;
-            load();
-        }
+	public ScheduleDelay getDelay() {
+		return delay;
+	}
 
-        /**
-         * @return timeout for regular expressions.
-         * @since 1.16.1
-         */
-        public long getRegexpTimeoutMs() {
-            return regexpTimeoutMs;
-        }
+	public int getMaxSchedule() {
+		return maxSchedule;
+	}
 
-        /**
-         * @param regexpTimeoutMs timeout for regular expressions.
-         * @since 1.16.1
-         */
-        public void setRegexpTimeoutMs(long regexpTimeoutMs) {
-            this.regexpTimeoutMs = regexpTimeoutMs;
-        }
+	@Override
+	public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
+			BuildListener listener) throws InterruptedException, IOException {
+		if (build instanceof MatrixRun) {
+			if (getRegexpForMatrixStrategy() == RegexpForMatrixStrategy.TestChildrenRetriggerMatched
+					&& !isRerunMatrixPart()) {
+				listener.getLogger().println(
+						"[Naginator] Warning: TestChildrenRetriggerMatched doesn't work without rerunMatrixPart");
+			}
 
-        /**
-         * @see hudson.model.Descriptor#configure(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObject)
-         */
-        @Override
-        public boolean configure(StaplerRequest req, JSONObject json) throws hudson.model.Descriptor.FormException {
-            setRegexpTimeoutMs(json.getLong("regexpTimeoutMs"));
-            boolean result = super.configure(req, json);
-            save();
-            return result;
-        }
+			MatrixBuild parent = ((MatrixRun) build).getParentBuild();
+			if (parent.getAction(NaginatorPublisherScheduleAction.class) == null) {
+				// No strict exclusion is required
+				// as it doesn't matter if the action gets duplicated.
+				parent.addAction(new NaginatorPublisherScheduleAction(this));
+			}
+		} else {
+			build.addAction(new NaginatorPublisherScheduleAction(this));
+		}
+		return true;
+	}
 
-        /**
-         * This human readable name is used in the configuration screen.
-         */
-        public String getDisplayName() {
-            return "Retry build after failure";
-        }
+	public BuildStepMonitor getRequiredMonitorService() {
+		return BuildStepMonitor.NONE;
+	}
 
-        @Override
-        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
-            return true;
-        }
+	@Override
+	public DescriptorImpl getDescriptor() {
+		// see Descriptor javadoc for more about what a descriptor is.
+		return (DescriptorImpl) super.getDescriptor();
+	}
 
-        /**
-         * Creates a new instance of {@link NaginatorPublisher} from a submitted form.
-         */
-        @Override
-        public Notifier newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-            return req.bindJSON(NaginatorPublisher.class, formData);
-        }
-        
-        /**
-         * @return true if the current request is for a matrix project.
-         */
-        public boolean isMatrixProject(Object it) {
-            return (it instanceof MatrixProject);
-        }
-        
-        public FormValidation doCheckRegexpForMatrixStrategy(
-                @QueryParameter RegexpForMatrixStrategy value,
-                @QueryParameter boolean rerunMatrixPart
-        ) {
-            // called only when regexpForMatrixStrategy is displayed,
-            // and we can assume that this is a matrix project.
-            if (value == RegexpForMatrixStrategy.TestChildrenRetriggerMatched && !rerunMatrixPart) {
-                return FormValidation.warning(Messages.NaginatorPublisher_RegexpForMatrixStrategy_RerunMatrixPartShouldBeEnabled());
-            }
-            return FormValidation.ok();
-        }
-        
-        public ListBoxModel doFillRegexpForMatrixStrategyItems() {
-            ListBoxModel ret = new ListBoxModel();
-            for (RegexpForMatrixStrategy strategy: RegexpForMatrixStrategy.values()) {
-                ret.add(strategy.getDisplayName(), strategy.name());
-            }
-            return ret;
-        }
-    }
+	@Extension
+	public final static NaginatorListener LISTENER = new NaginatorListener();
 
-    private static final Logger LOGGER = Logger.getLogger(NaginatorPublisher.class.getName());
+	@Extension
+	public static final class DescriptorImpl
+			extends BuildStepDescriptor<Publisher> {
+		private long regexpTimeoutMs;
+
+		public DescriptorImpl() {
+			// default value
+			regexpTimeoutMs = DEFAULT_REGEXP_TIMEOUT_MS;
+			load();
+		}
+
+		/**
+		 * @return timeout for regular expressions.
+		 * @since 1.16.1
+		 */
+		public long getRegexpTimeoutMs() {
+			return regexpTimeoutMs;
+		}
+
+		/**
+		 * @param regexpTimeoutMs timeout for regular expressions.
+		 * @since 1.16.1
+		 */
+		public void setRegexpTimeoutMs(long regexpTimeoutMs) {
+			this.regexpTimeoutMs = regexpTimeoutMs;
+		}
+
+		/**
+		 * @see hudson.model.Descriptor#configure(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObject)
+		 */
+		@Override
+		public boolean configure(StaplerRequest req, JSONObject json)
+				throws hudson.model.Descriptor.FormException {
+			setRegexpTimeoutMs(json.getLong("regexpTimeoutMs"));
+			boolean result = super.configure(req, json);
+			save();
+			return result;
+		}
+
+		/**
+		 * This human readable name is used in the configuration screen.
+		 */
+		public String getDisplayName() {
+			return "Retry build after failure";
+		}
+
+		@Override
+		public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+			return true;
+		}
+
+		/**
+		 * Creates a new instance of {@link NaginatorPublisher} from a submitted form.
+		 */
+		@Override
+		public Notifier newInstance(StaplerRequest req, JSONObject formData)
+				throws FormException {
+			return req.bindJSON(NaginatorPublisher.class, formData);
+		}
+
+		public boolean isMatrixProject(Object it) {
+			return (it instanceof MatrixProject);
+		}
+
+		public FormValidation doCheckRegexpForMatrixStrategy(
+				@QueryParameter RegexpForMatrixStrategy value,
+				@QueryParameter boolean rerunMatrixPart) {
+			// called only when regexpForMatrixStrategy is displayed,
+			// and we can assume that this is a matrix project.
+			if (value == RegexpForMatrixStrategy.TestChildrenRetriggerMatched
+					&& !rerunMatrixPart) {
+				return FormValidation.warning(Messages
+						.NaginatorPublisher_RegexpForMatrixStrategy_RerunMatrixPartShouldBeEnabled());
+			}
+			return FormValidation.ok();
+		}
+
+		public ListBoxModel doFillRegexpForMatrixStrategyItems() {
+			ListBoxModel ret = new ListBoxModel();
+			for (RegexpForMatrixStrategy strategy : RegexpForMatrixStrategy
+					.values()) {
+				ret.add(strategy.getDisplayName(), strategy.name());
+			}
+			return ret;
+		}
+	}
+
+	private static final Logger LOGGER = Logger
+			.getLogger(NaginatorPublisher.class.getName());
 
 }

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisherScheduleAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisherScheduleAction.java
@@ -6,6 +6,8 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 
+import static org.junit.Assert.assertFalse;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -26,276 +28,335 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 import jenkins.model.Jenkins;
+import static java.lang.Boolean.parseBoolean;
+import static org.hamcrest.Matchers.greaterThan;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
 /**
  * Used from {@link NaginatorPublisher} to mark a build to be reshceduled.
- * 
+ *
  * @since 1.16
  */
 public class NaginatorPublisherScheduleAction extends NaginatorScheduleAction {
-    private static final Logger LOGGER = Logger.getLogger(NaginatorPublisherScheduleAction.class.getName());
-    
-    private final String regexpForRerun;
-    private final boolean rerunIfUnstable;
-    private final boolean checkRegexp;
-    private transient Boolean regexpForMatrixParent;        // for backward compatibility
-    private /* almost final */ RegexpForMatrixStrategy regexpForMatrixStrategy;
-    private final NoChildStrategy noChildStrategy;
-    
-    public NaginatorPublisherScheduleAction(NaginatorPublisher publisher) {
-        super(publisher.getMaxSchedule(), publisher.getDelay(), publisher.isRerunMatrixPart());
-        this.regexpForRerun = publisher.getRegexpForRerun();
-        this.rerunIfUnstable = publisher.isRerunIfUnstable();
-        this.checkRegexp = publisher.isCheckRegexp();
-        this.regexpForMatrixStrategy = publisher.getRegexpForMatrixStrategy();
-        this.noChildStrategy = publisher.getNoChildStrategy();
-    }
-    
-    public Object readResolve() {
-        if (regexpForMatrixStrategy == null) {
-            // < 1.17
-            if (regexpForMatrixParent != null) {
-                regexpForMatrixStrategy = 
-                        regexpForMatrixParent.booleanValue()
-                        ? RegexpForMatrixStrategy.TestParent
-                        : RegexpForMatrixStrategy.TestChildrenRetriggerMatched;
-                regexpForMatrixParent = null;
-            } else {
-                // something strange.
-                regexpForMatrixStrategy = RegexpForMatrixStrategy.getDefault();
-            }
-        }
-        return this;
-    }
-    
-    @CheckForNull
-    public String getRegexpForRerun() {
-        return regexpForRerun;
-    }
-    
-    public boolean isRerunIfUnstable() {
-        return rerunIfUnstable;
-    }
-    
-    public boolean isCheckRegexp() {
-        return checkRegexp;
-    }
-    
-    /**
-     * @deprecated use {@link #getRegexpForMatrixStrategy()}
-     */
-    @Deprecated
-    public boolean isRegexpForMatrixParent() {
-        return getRegexpForMatrixStrategy() == RegexpForMatrixStrategy.TestParent;
-    }
-    
-    /**
-     * @since 1.17
-     */
-    @Nonnull
-    public RegexpForMatrixStrategy getRegexpForMatrixStrategy() {
-        return regexpForMatrixStrategy;
-    }
-    
-    @Override
-    public boolean shouldSchedule(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener, int retryCount) {
-        if (!checkCommonScheduleThreshold(run)) {
-            return false;
-        }
-        
-        // If we're supposed to check for a regular expression in the build output before
-        // scheduling a new build, do so.
-        if (isCheckRegexp() && (!(run instanceof MatrixBuild) || getRegexpForMatrixStrategy() == RegexpForMatrixStrategy.TestParent)) {
-            LOGGER.log(Level.FINEST, "Got checkRegexp == true");
-            
-            if (!testRegexp(run, listener)) {
-                return false;
-            }
-        } else if (
-                isCheckRegexp()
-                && (run instanceof MatrixBuild)
-                && getRegexpForMatrixStrategy() == RegexpForMatrixStrategy.TestChildrenRetriggerAll
-        ) {
-            // check should be performed for child builds here.
-            if (!testRegexpForFailedChildren((MatrixBuild)run, listener)) {
-                return false;
-            }
-        }
-        
-        return super.shouldSchedule(run, listener, retryCount);
-    }
+	private static final Logger LOGGER = Logger
+			.getLogger(NaginatorPublisherScheduleAction.class.getName());
 
-    private boolean testRegexpForFailedChildren(@Nonnull MatrixBuild run, @Nonnull TaskListener listener) {
-        for (MatrixRun r : ((MatrixBuild)run).getExactRuns()) {
-            if (!checkCommonScheduleThreshold(r)) {
-                continue;
-            }
-            if (testRegexp(r, listener)) {
-                return true;
-            }
-        }
-        // no children matched.
-        return false;
-    }
+	private final String regexpForRerun;
+	private final boolean rerunIfUnstable;
+	private final boolean checkRegexp;
+	private Pattern pattern;
+	private Matcher matcher;
+	private transient Boolean regexpForMatrixParent; // for backward compatibility
+	private /* almost final */ RegexpForMatrixStrategy regexpForMatrixStrategy;
+	private final NoChildStrategy noChildStrategy;
+	private NaginatorPublisher naginatorPublisher;
 
-    @Override
-    public boolean shouldScheduleForMatrixRun(@Nonnull MatrixRun run, @Nonnull TaskListener listener) {
-        if (!checkCommonScheduleThreshold(run)) {
-            return false;
-        }
-        if (isCheckRegexp() && getRegexpForMatrixStrategy() == RegexpForMatrixStrategy.TestChildrenRetriggerMatched) {
-            LOGGER.log(Level.FINEST, "Got isRerunMatrixPart == true");
-            
-            if (!testRegexp(run, listener)) {
-                return false;
-            }
-        }
-        return true;
-    }
-    
-    private boolean checkCommonScheduleThreshold(@Nonnull Run<?, ?> run) {
-        if ((run.getResult() == Result.SUCCESS) || (run.getResult() == Result.ABORTED)) {
-            return false;
-        }
-        
-        // If we're not set to rerun if unstable, and the build's unstable, return true.
-        if ((!isRerunIfUnstable()) && (run.getResult() == Result.UNSTABLE)) {
-            return false;
-        }
-        return true;
-    }
-    
-    private boolean testRegexp(@Nonnull Run<?, ?> run, TaskListener listener) {
-        String regexpForRerun = getRegexpForRerun();
-        if ((regexpForRerun != null) && (!regexpForRerun.equals(""))) {
-            LOGGER.log(Level.FINEST, "regexpForRerun - {0}", regexpForRerun);
-            
-            try {
-                // If parseLog returns false, we didn't find the regular expression,
-                // so return true.
-                if (!parseLog(run.getLogFile(), run.getCharset(), regexpForRerun)) {
-                    LOGGER.log(Level.FINEST, "regexp not in logfile");
-                    return false;
-                }
-            } catch (IOException e) {
-                e.printStackTrace(listener
-                                  .error("error while parsing logs for naginator - forcing rebuild."));
-            }
-        }
-        return true;
-    }
-    
-    private long getRegexpTimeoutMs() {
-        Jenkins j = Jenkins.getInstance();
-        if (j == null) {
-            return NaginatorPublisher.DEFAULT_REGEXP_TIMEOUT_MS;
-        }
-        NaginatorPublisher.DescriptorImpl d = (NaginatorPublisher.DescriptorImpl)j.getDescriptor(NaginatorPublisher.class);
-        if (d == null) {
-            return NaginatorPublisher.DEFAULT_REGEXP_TIMEOUT_MS;
-        }
-        return d.getRegexpTimeoutMs();
-    }
-    
-    private boolean parseLog(final File logFile, final Charset charset, @Nonnull final String regexp) throws IOException {
-        // TODO annotate `logFile` with `@Nonnull`
-        // after upgrading the target Jenkins to 1.568 or later.
-        
-        long timeout = getRegexpTimeoutMs();
-        
-        FutureTask<Boolean> task = new FutureTask<Boolean>(new Callable<Boolean>() {
-            public Boolean call() throws Exception {
-                return parseLogImpl(logFile, charset, regexp);
-            }
-        });
-        
-        Thread t = new Thread(task);
-        t.start();
-        
-        try {
-            // never null
-            return task.get(timeout, TimeUnit.MILLISECONDS);
-        } catch (TimeoutException e) {
-            LOGGER.log(
-                    Level.WARNING,
-                    String.format("Aborted regexp '%s' for too long execution time ( > %d ms).", regexp, timeout)
-            );
-        } catch (InterruptedException e) {
-            LOGGER.log(
-                    Level.SEVERE,
-                    String.format("Aborted regexp '%s'", regexp),
-                    e
-            );
-        } catch (ExecutionException e) {
-            LOGGER.log(
-                    Level.SEVERE,
-                    String.format("Aborted regexp '%s'", regexp),
-                    e
-            );
-        }
-        if (t.isAlive()) {
-            t.interrupt();
-        }
-        try {
-            t.join();
-        } catch (InterruptedException e) {
-            // ok
-        }
-        return false;
-    }
-    
-    private static class InterruptibleCharSequence implements CharSequence {
-        private final CharSequence wrapped;
-        
-        public InterruptibleCharSequence(CharSequence wrapped) {
-            this.wrapped = wrapped;
-        }
-        
-        public int length() {
-            return wrapped.length();
-        }
-        
-        public char charAt(int index) {
-            if (Thread.currentThread().isInterrupted()) {
-                throw new RuntimeException(new InterruptedException());
-            }
-            return wrapped.charAt(index);
-        }
-        
-        public CharSequence subSequence(int start, int end) {
-            return wrapped.subSequence(start, end);
-        }
-    }
-    
-    private boolean parseLogImpl(File logFile, Charset charset, @Nonnull final String regexp) throws IOException {
-        // TODO annotate `logFile` and 'charset' with `@Nonnull`
-        // after upgrading the target Jenkins to 1.568 or later.
+	public NaginatorPublisherScheduleAction(NaginatorPublisher publisher) {
+		super(publisher.getMaxSchedule(), publisher.getDelay(),
+				publisher.isRerunMatrixPart());
+		this.naginatorPublisher = publisher;
+		this.regexpForRerun = publisher.getRegexpForRerun();
+		this.rerunIfUnstable = publisher.isRerunIfUnstable();
+		this.checkRegexp = publisher.isCheckRegexp();
+		this.regexpForMatrixStrategy = publisher.getRegexpForMatrixStrategy();
+		this.noChildStrategy = publisher.getNoChildStrategy();
+	}
 
-        // Assume default encoding and text files
-        String line;
-        Pattern pattern = Pattern.compile(regexp);
-        BufferedReader reader = null;
-        try {
-            reader = new BufferedReader(new InputStreamReader(new FileInputStream(logFile), charset));
-            while ((line = reader.readLine()) != null) {
-                Matcher matcher = pattern.matcher(new InterruptibleCharSequence(line));
-                if (matcher.find()) {
-                    return true;
-                }
-            }
-            return false;
-        } finally {
-            if (reader != null) {
-                reader.close();
-            }
-        }
-    }
-    
-    @Override
-    @Nonnull
-    public NoChildStrategy getNoChildStrategy() {
-        return (noChildStrategy != null)
-                ? noChildStrategy
-                : NoChildStrategy.getDefault();
-    }
+	public Object readResolve() {
+		if (regexpForMatrixStrategy == null) {
+			// < 1.17
+			if (regexpForMatrixParent != null) {
+				regexpForMatrixStrategy = regexpForMatrixParent.booleanValue()
+						? RegexpForMatrixStrategy.TestParent
+						: RegexpForMatrixStrategy.TestChildrenRetriggerMatched;
+				regexpForMatrixParent = null;
+			} else {
+				// something strange.
+				regexpForMatrixStrategy = RegexpForMatrixStrategy.getDefault();
+			}
+		}
+		return this;
+	}
+
+	@CheckForNull
+	public String getRegexpForRerun() {
+		return regexpForRerun;
+	}
+
+	public boolean isRerunIfUnstable() {
+		return rerunIfUnstable;
+	}
+
+	public boolean isCheckRegexp() {
+		return checkRegexp;
+	}
+
+	@Deprecated
+	public boolean isRegexpForMatrixParent() {
+		return getRegexpForMatrixStrategy() == RegexpForMatrixStrategy.TestParent;
+	}
+
+	@Nonnull
+	public RegexpForMatrixStrategy getRegexpForMatrixStrategy() {
+		return regexpForMatrixStrategy;
+	}
+
+	@Override
+	public boolean shouldSchedule(@Nonnull Run<?, ?> run,
+			@Nonnull TaskListener listener, int retryCount) {
+		if (!checkCommonScheduleThreshold(run)) {
+			return false;
+		}
+
+		// If we're supposed to check for a regular expression in the build output
+		// before
+		// scheduling a new build, do so.
+		if (isCheckRegexp() && (!(run instanceof MatrixBuild)
+				|| getRegexpForMatrixStrategy() == RegexpForMatrixStrategy.TestParent)) {
+			LOGGER.log(Level.FINEST, "Got checkRegexp == true");
+
+			if (!testRegexp(run, listener)) {
+				return false;
+			}
+		} else if (isCheckRegexp() && (run instanceof MatrixBuild)
+				&& getRegexpForMatrixStrategy() == RegexpForMatrixStrategy.TestChildrenRetriggerAll) {
+			// check should be performed for child builds here.
+			if (!testRegexpForFailedChildren((MatrixBuild) run, listener)) {
+				return false;
+			}
+		}
+		return super.shouldSchedule(run, listener, retryCount);
+	}
+
+	private boolean testRegexpForFailedChildren(@Nonnull MatrixBuild run,
+			@Nonnull TaskListener listener) {
+		for (MatrixRun r : ((MatrixBuild) run).getExactRuns()) {
+			if (!checkCommonScheduleThreshold(r)) {
+				continue;
+			}
+			if (testRegexp(r, listener)) {
+				return true;
+			}
+		}
+		// no children matched.
+		return false;
+	}
+
+	@Override
+	public boolean shouldScheduleForMatrixRun(@Nonnull MatrixRun run,
+			@Nonnull TaskListener listener) {
+		if (!checkCommonScheduleThreshold(run)) {
+			return false;
+		}
+		if (isCheckRegexp()
+				&& getRegexpForMatrixStrategy() == RegexpForMatrixStrategy.TestChildrenRetriggerMatched) {
+			LOGGER.log(Level.FINEST, "Got isRerunMatrixPart == true");
+
+			if (!testRegexp(run, listener)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private boolean checkCommonScheduleThreshold(@Nonnull Run<?, ?> run) {
+		if ((run.getResult() == Result.SUCCESS)
+				|| (run.getResult() == Result.ABORTED)) {
+			return false;
+		}
+
+		// If we're not set to rerun if unstable, and the build's unstable, return
+		// true.
+		if ((!isRerunIfUnstable()) && (run.getResult() == Result.UNSTABLE)) {
+			return false;
+		}
+		return true;
+	}
+
+	private boolean testRegexp(@Nonnull Run<?, ?> run, TaskListener listener) {
+		String regexpForRerun = getRegexpForRerun();
+		if ((regexpForRerun != null) && (!regexpForRerun.equals(""))) {
+			LOGGER.log(Level.FINEST, "regexpForRerun - {0}", regexpForRerun);
+
+			try {
+				// If parseLog returns false, we didn't find the regular expression,
+				// so return true.
+				if (!parseLog(run.getLogFile(), run.getCharset(), regexpForRerun)) {
+					LOGGER.log(Level.FINEST, "regexp not in logfile");
+					return false;
+				}
+			} catch (IOException e) {
+				e.printStackTrace(listener.error(
+						"error while parsing logs for naginator - forcing rebuild."));
+			}
+		}
+		return true;
+	}
+
+	private long getRegexpTimeoutMs() {
+		Jenkins j = Jenkins.getInstance();
+		if (j == null) {
+			return NaginatorPublisher.DEFAULT_REGEXP_TIMEOUT_MS;
+		}
+		NaginatorPublisher.DescriptorImpl d = (NaginatorPublisher.DescriptorImpl) j
+				.getDescriptor(NaginatorPublisher.class);
+		if (d == null) {
+			return NaginatorPublisher.DEFAULT_REGEXP_TIMEOUT_MS;
+		}
+		return d.getRegexpTimeoutMs();
+	}
+
+	/**
+	 * Finds out whether the build is to be rescheduled.
+	 *
+	 * @param logFile the build log to examine
+	 * @param charset the charset used by the build.
+	 * @return whether to reschedule the build.
+	 */
+	private boolean parseLog(final File logFile, final Charset charset,
+			@Nonnull final String regexp) throws IOException {
+		// TODO annotate `logFile` with `@Nonnull`
+		// after upgrading the target Jenkins to 1.568 or later.
+
+		long timeout = getRegexpTimeoutMs();
+
+		FutureTask<Boolean> task = new FutureTask<Boolean>(new Callable<Boolean>() {
+			public Boolean call() throws Exception {
+				return parseLogImpl(logFile, charset, regexp);
+			}
+		});
+
+		Thread t = new Thread(task);
+		t.start();
+
+		try {
+			// never null
+			return task.get(timeout, TimeUnit.MILLISECONDS);
+		} catch (TimeoutException e) {
+			LOGGER.log(Level.WARNING,
+					String.format(
+							"Aborted regexp '%s' for too long execution time ( > %d ms).",
+							regexp, timeout));
+		} catch (InterruptedException e) {
+			LOGGER.log(Level.SEVERE, String.format("Aborted regexp '%s'", regexp), e);
+		} catch (ExecutionException e) {
+			LOGGER.log(Level.SEVERE, String.format("Aborted regexp '%s'", regexp), e);
+		}
+		if (t.isAlive()) {
+			t.interrupt();
+		}
+		try {
+			t.join();
+		} catch (InterruptedException e) {
+			// ok
+		}
+		return false;
+	}
+
+	private static class InterruptibleCharSequence implements CharSequence {
+		private final CharSequence wrapped;
+
+		public InterruptibleCharSequence(CharSequence wrapped) {
+			this.wrapped = wrapped;
+		}
+
+		public int length() {
+			return wrapped.length();
+		}
+
+		public char charAt(int index) {
+			if (Thread.currentThread().isInterrupted()) {
+				throw new RuntimeException(new InterruptedException());
+			}
+			return wrapped.charAt(index);
+		}
+
+		public CharSequence subSequence(int start, int end) {
+			return wrapped.subSequence(start, end);
+		}
+	}
+
+	/**
+	 * Extracts the maxSchedule from build log message against the "Search for Log message" regexp.
+	 *
+	 * @param message build log message to examine
+	 * @param regexp string containing regular expression to locate. The data is expected to be in the capture group 1
+	 * @return the matched integer value
+	 */
+	private int getMessageData(@Nonnull final String message,
+			@Nonnull final String regexp) {
+
+		pattern = Pattern.compile(regexp);
+		int data = 0;
+		LOGGER.log(Level.FINEST, "Processing message: " + message);
+		matcher = pattern.matcher(message);
+		if (matcher.find()) {
+			data = Integer.parseInt(matcher.group(1));
+			assertThat(data, greaterThan(0));
+			LOGGER.log(Level.FINEST, "Extracted data: " + data);
+		} else {
+			LOGGER.log(Level.FINEST, "Failed to find data in the message: " + message);
+
+		}
+		return data;
+	}
+
+	/**
+	 * Finds the "Search for Log message" regexp in the build console output
+	 * @param logFile build log to examine
+	 * @param charset charset used to load the log
+	 * @param regexp string to find
+	 * @return whether to reschedule the build
+	 * @see getMaxSchedule
+	 */
+	private boolean parseLogImpl(File logFile, Charset charset,
+			@Nonnull final String regexp) throws IOException {
+		// TODO annotate `logFile` and 'charset' with `@Nonnull`
+		// after upgrading the target Jenkins to 1.568 or later.
+
+		// Assume default encoding and text files
+		String line;
+		pattern = Pattern.compile(regexp);
+		BufferedReader reader = null;
+		try {
+			reader = new BufferedReader(
+					new InputStreamReader(new FileInputStream(logFile), charset));
+			while ((line = reader.readLine()) != null) {
+				matcher = pattern.matcher(new InterruptibleCharSequence(line));
+				if (matcher.find()) {
+					String message = matcher.group(0);
+					LOGGER.log(Level.FINEST, "Found Log message: " + message);
+
+					if (naginatorPublisher.isMaxScheduleOverrideAllowed()) {
+						int maxScheduleOverride = getMessageData(message, regexp);
+						if (maxScheduleOverride != 0) {
+							LOGGER.log(Level.FINEST,
+									"Updating maxScheduleOverride: " + maxScheduleOverride);
+							naginatorPublisher.setMaxSchedule(maxScheduleOverride);
+						}
+					}
+					return true;
+				}
+			}
+			return false;
+		} finally {
+			if (reader != null) {
+				reader.close();
+			}
+		}
+	}
+
+	@Override
+	@Nonnull
+	public NoChildStrategy getNoChildStrategy() {
+		return (noChildStrategy != null) ? noChildStrategy
+				: NoChildStrategy.getDefault();
+	}
 }

--- a/src/main/java/com/chikli/hudson/plugin/naginator/ProgressiveDelay.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/ProgressiveDelay.java
@@ -9,7 +9,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
 /**
- * @author: <a hef="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ * @author: <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class ProgressiveDelay extends ScheduleDelay {
 

--- a/src/main/java/com/chikli/hudson/plugin/naginator/ScheduleDelay.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/ScheduleDelay.java
@@ -7,7 +7,7 @@ import jenkins.model.Jenkins;
 
 /**
  * Defines schedules policy to trigger a new build after failure
- * @author: <a hef="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ * @author: <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public abstract class ScheduleDelay extends AbstractDescribableImpl<ScheduleDelay> {
 

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorCause/description.jelly
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorCause/description.jelly
@@ -1,28 +1,27 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <span>
+  <span>
+    <j:choose>
+      <j:when test="${it.sourceBuildNumber!=null}">
         <j:choose>
-            <j:when test="${it.sourceBuildNumber!=null}">
-
-                <j:choose>
-                    <j:when test="${it.project.getBuildByNumber(it.sourceBuildNumber)!=null}">
-                        <j:out value="${%DescriptionWithLinkToSource(it.summary,rootURL,it.jobUrl,it.sourceBuildNumber)}"/>
-                    </j:when>
-                    <j:otherwise>
-                        <j:out value="${%DescriptionWithDeletedSource(it.summary)}"/>
-                    </j:otherwise>
-                </j:choose>
-            </j:when>
-            <j:otherwise>
-                <j:choose>
-                    <j:when test="${it.summary!=null}">
-                        <j:out value="${it.shortDescription}"/>
-                    </j:when>
-                    <j:otherwise>
-                        <j:out value="${%DescriptionGeneral}"/>
-                    </j:otherwise>
-                </j:choose>
-            </j:otherwise>
+          <j:when test="${it.project.getBuildByNumber(it.sourceBuildNumber)!=null}">
+            <j:out value="${%DescriptionWithLinkToSource(it.summary,rootURL,it.jobUrl,it.sourceBuildNumber)}"/>
+          </j:when>
+          <j:otherwise>
+            <j:out value="${%DescriptionWithDeletedSource(it.summary)}"/>
+          </j:otherwise>
         </j:choose>
-    </span>
+      </j:when>
+      <j:otherwise>
+        <j:choose>
+          <j:when test="${it.summary!=null}">
+            <j:out value="${it.shortDescription}"/>
+          </j:when>
+          <j:otherwise>
+            <j:out value="${%DescriptionGeneral}"/>
+          </j:otherwise>
+        </j:choose>
+      </j:otherwise>
+    </j:choose>
+  </span>
 </j:jelly>

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/config.jelly
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/config.jelly
@@ -1,42 +1,40 @@
+<?xml version="1.0"?>
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <f:entry title="Rerun build for unstable builds as well as failures" field="rerunIfUnstable">
-        <f:checkbox />
+  <f:entry title="Rerun unstable builds" field="rerunIfUnstable">
+    <f:checkbox/>
+  </f:entry>
+  <j:if test="${descriptor.isMatrixProject(it)}">
+    <f:entry title="Rerun build only for failed parts on the matrix" field="rerunMatrixPart">
+      <f:checkbox/>
     </f:entry>
-
+  </j:if>
+  <f:entry title="${%Delay before retrying build}">
+    <j:invokeStatic var="delays" className="com.chikli.hudson.plugin.naginator.ScheduleDelay" method="all"/>
+    <f:hetero-radio descriptors="${delays}" field="delay"/>
+  </f:entry>
+  <f:entry title="${%Maximum retries}" field="maxSchedule">
+    <f:textbox/>
+  </f:entry>
+  <f:advanced>
     <j:if test="${descriptor.isMatrixProject(it)}">
-        <f:entry title="Rerun build only for failed parts on the matrix" field="rerunMatrixPart">
-            <f:checkbox />
-        </f:entry>
+      <f:entry title="${%When no combinations to rerun}" field="noChildStrategy">
+        <f:enum>${it.displayName}</f:enum>
+      </f:entry>
     </j:if>
-
-    <f:entry title="${%Delay before retrying build}">
-        <j:invokeStatic var="delays" className="com.chikli.hudson.plugin.naginator.ScheduleDelay" method="all"/>
-        <f:hetero-radio descriptors="${delays}" field="delay"/>
-    </f:entry>
-
-    <f:entry title="${%Maximum number of successive failed builds}" field="maxSchedule">
+    <f:optionalBlock field="checkRegexp" inline="true" title="${%Only rerun if log message is found}">
+      <f:entry title="${%Search for Log message}" field="regexpForRerun">
         <f:textbox/>
-    </f:entry>
-
-    <f:advanced>
-        <j:if test="${descriptor.isMatrixProject(it)}">
-            <f:entry title="${%When no combinations to rerun}" field="noChildStrategy">
-                <f:enum>${it.displayName}</f:enum>
-            </f:entry>
-        </j:if>
-        <f:optionalBlock field="checkRegexp" inline="true"
-                 title="${%Only rerun build if regular expression is found in output}">
-            <f:entry title="${%Regular expression to search for}" field="regexpForRerun">
-                <f:textbox />
-            </f:entry>
-            <j:if test="${descriptor.isMatrixProject(it)}">
-                <f:entry title="${%How to apply the regular expression to matrix}" field="regexpForMatrixStrategy">
-                    <!-- unfortunatelly, f:enum doesn't support doCheckXxxx -->
-                    <f:select />
-                </f:entry>
-            </j:if>
-        </f:optionalBlock>
-    </f:advanced>
-
+      </f:entry>
+      <j:if test="${descriptor.isMatrixProject(it)}">
+        <f:entry title="${%How to apply the regular expression to matrix}" field="regexpForMatrixStrategy">
+          <!-- unfortunatelly, f:enum doesn't support doCheckXxxx -->
+          <f:select/>
+        </f:entry>
+      </j:if>
+      <f:entry title="Override maximum retries" field="maxScheduleOverrideAllowed">
+        <f:checkbox/>
+      </f:entry>
+    </f:optionalBlock>
+  </f:advanced>
 </j:jelly>

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/global.jelly
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/global.jelly
@@ -1,8 +1,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-<f:section title="${descriptor.displayName}">
-  <f:entry field="regexpTimeoutMs" title="${%Timeout for regular expressions (ms)}">
-    <f:textbox />
-  </f:entry>
-</f:section>
+  <f:section title="${descriptor.displayName}">
+    <f:entry field="regexpTimeoutMs" title="${%Timeout for regular expressions (ms)}">
+      <f:textbox/>
+    </f:entry>
+  </f:section>
 </j:jelly>

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/help-maxSchedule.html
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/help-maxSchedule.html
@@ -1,3 +1,3 @@
 <div>
-    Limits successive failed build retries. Set to 0 for no limit.
+Limits successive failed build retries. Set to 0 for no limit.
 </div>

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/help-maxScheduleOverrideAllowed.html
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/help-maxScheduleOverrideAllowed.html
@@ -1,0 +1,17 @@
+<div>
+Allow Log parser to extract the maximum number of successive failed build retries from the failure log message. 
+Clear to enforce the configuration value to be always used.
+The Regular expression to search for will need to have a integer number in its first match group e.g.
+<br/>
+<pre>ERROR: (?:NETWORK ERROR|ARTIFACTORY ERROR) RETRY: (\d)</pre>
+<br/>
+and the log message 
+<pre>
+ERROR: NETWORK ERROR RETRY: 2
+</pre>
+and
+<pre>
+ERROR: ARTIFACTORY ERROR RETRY: 1
+</pre>
+in the build console output would trigger <b>2</b> and <b>1</b> maximum reruns.
+</div>

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/help-rerunIfUnstable.html
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorPublisher/help-rerunIfUnstable.html
@@ -1,0 +1,3 @@
+<div>
+Rerun build for unstable builds as well as failures
+</div>


### PR DESCRIPTION
This allows e.g. setting *Search for Log message* to `ERROR: (?:NETWORK ERROR|ARTIFACTORY ERROR) RETRY: (\d)` and log message `ERROR: NETWORK ERROR RETRY: 2` will be rerun the build max _2_ times while `ERROR: NETWORK ERROR RETRY: 3` in some other failure will rerun 3 times. 

Updated code, help and templates
