### PR TITLE
Update to Jenkins 1.565

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>1.554</jenkins.version>
+    <jenkins.version>1.565</jenkins.version>
     <java.level>6</java.level>
   </properties>
   
@@ -75,6 +75,11 @@
     </pluginRepositories>
     
     <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.0</version>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>

--- a/src/main/java/com/chikli/hudson/plugin/naginator/FixedDelay.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/FixedDelay.java
@@ -6,7 +6,7 @@ import hudson.model.AbstractBuild;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
- * @author: <a hef="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ * @author: <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class FixedDelay extends ScheduleDelay {
 

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorAction.java
@@ -6,7 +6,7 @@ import hudson.model.BuildBadgeAction;
 import hudson.model.Run;
 
 /**
- * @author: <a hef="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ * @author: <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class NaginatorAction implements BuildBadgeAction {
     private final int retryCount;

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisher.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisher.java
@@ -31,7 +31,7 @@ import javax.annotation.Nonnull;
 /**
  * Reschedules a build if the current one fails.
  *
- * @author Nayan Hajratwala <nayan@chikli.com>
+ * @author Nayan Hajratwala &lt;nayan@chikli.com&gt;
  */
 public class NaginatorPublisher extends Notifier {
     public final static long DEFAULT_REGEXP_TIMEOUT_MS = 30000;
@@ -146,8 +146,8 @@ public class NaginatorPublisher extends Notifier {
     /**
      * Returns whether apply the regexp to the matrix parent instead of matrix children.
      * 
-     * The default is <code>false</code> for naginator-plugin >= 1.16
-     * though <code>true</code> for configurations upgraded from naginator-plugin < 1.16.
+     * The default is <code>false</code> for naginator-plugin &gt;= 1.16
+     * though <code>true</code> for configurations upgraded from naginator-plugin &lt; 1.16.
      * 
      * @return Returns whether apply the regexp to the matrix parent instead of matrix children
      * @since 1.16

--- a/src/main/java/com/chikli/hudson/plugin/naginator/ProgressiveDelay.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/ProgressiveDelay.java
@@ -9,7 +9,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
 /**
- * @author: <a hef="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ * @author: <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class ProgressiveDelay extends ScheduleDelay {
 

--- a/src/main/java/com/chikli/hudson/plugin/naginator/ScheduleDelay.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/ScheduleDelay.java
@@ -7,7 +7,7 @@ import jenkins.model.Jenkins;
 
 /**
  * Defines schedules policy to trigger a new build after failure
- * @author: <a hef="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ * @author: <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public abstract class ScheduleDelay extends AbstractDescribableImpl<ScheduleDelay> {
 

--- a/src/main/java/com/chikli/hudson/plugin/naginator/ScheduleDelay.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/ScheduleDelay.java
@@ -14,7 +14,11 @@ public abstract class ScheduleDelay extends AbstractDescribableImpl<ScheduleDela
     public abstract int computeScheduleDelay(AbstractBuild failedBuild);
 
     public static DescriptorExtensionList<ScheduleDelay, Descriptor<ScheduleDelay>> all() {
-        return Jenkins.getInstance().getDescriptorList(ScheduleDelay.class);
+        Jenkins j = Jenkins.getInstance();
+        if (j == null) {
+            return null;
+        }
+        return j.getDescriptorList(ScheduleDelay.class);
     }
 
     public static abstract class ScheduleDelayDescriptor extends Descriptor<ScheduleDelay> {


### PR DESCRIPTION
Jenkins 1.554 no longer works with Java8 for [JENKINS-18537](https://issues.jenkins-ci.org/browse/JENKINS-18537).

This is a replay of #37.
And this also includes Javadoc error fixes (#43).
