### PR TITLE
[JENKINS-63273] Fix test failures for old maven repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.9</version>
+    <version>2.37</version>
   </parent>
   
   <name>Naginator</name>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,16 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <dependencyManagement>
+        <!-- To resolve RequireUpperBoundDeps errors -->
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.ant</groupId>
+                <artifactId>ant</artifactId>
+                <version>1.9.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>  
   
 

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorListenerTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorListenerTest.java
@@ -448,6 +448,18 @@ public class NaginatorListenerTest extends HudsonTestCase {
                 "  <artifactId>test</artifactId>",
                 "  <version>1.0</version>",
                 "  <packaging>jar</packaging>",
+                "  <repositories>",
+                "    <repository>",
+                "      <id>central</id>",
+                "      <url>https://repo.maven.apache.org/maven2</url>",
+                "    </repository>",
+                "  </repositories>",
+                "  <pluginRepositories>",
+                "    <pluginRepository>",
+                "      <id>central</id>",
+                "      <url>https://repo.maven.apache.org/maven2</url>",
+                "    </pluginRepository>",
+                "  </pluginRepositories>",
                 "</project>"
         }, "\n");
         


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-63273

A test fails for `http://repo1.maven.org/maven2` is no longer available:
```
[INFO] Error building POM (may not be this project's POM).
Project ID: org.apache.maven.plugins:maven-clean-plugin
Reason: POM 'org.apache.maven.plugins:maven-clean-plugin' not found in repository: Unable to download the artifact from any repository
  org.apache.maven.plugins:maven-clean-plugin:pom:2.2
from the specified remote repositories:
  central (http://repo1.maven.org/maven2)
 for project org.apache.maven.plugins:maven-clean-plugin
```
