### PR TITLE
[JENKINS-59222] document user on retry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,12 @@
             <artifactId>ionicons-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>buildtriggerbadge</artifactId>
+            <version>251.vdf6ef853f3f5</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorAction.java
@@ -53,7 +53,7 @@ public class NaginatorAction implements BuildBadgeAction {
         if (cause != null) {
             return cause.getShortDescription();
         }
-        return "";
+        return Messages.NaginatorAction_rescheduled();
     }
     public String getIconFileName() {
         return null;

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorAction.java
@@ -2,6 +2,7 @@ package com.chikli.hudson.plugin.naginator;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.model.BuildBadgeAction;
+import hudson.model.Cause;
 import hudson.model.Run;
 
 /**
@@ -11,6 +12,8 @@ public class NaginatorAction implements BuildBadgeAction {
     private final int retryCount;
     private final int maxRetryCount;
     private final Integer parentBuildNumber;
+
+    private Cause cause = null;
 
     /**
      * @deprecated use {@link NaginatorAction#NaginatorAction(int)}
@@ -42,6 +45,16 @@ public class NaginatorAction implements BuildBadgeAction {
         this.maxRetryCount = maxRetryCount;
     }
 
+    public void setCause(Cause cause) {
+        this.cause = cause;
+    }
+
+    public String getTooltip() {
+        if (cause != null) {
+            return cause.getShortDescription();
+        }
+        return "";
+    }
     public String getIconFileName() {
         return null;
     }

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorBuildTriggerBadgeDeactivator.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorBuildTriggerBadgeDeactivator.java
@@ -1,0 +1,14 @@
+package com.chikli.hudson.plugin.naginator;
+
+import hudson.Extension;
+import hudson.model.Cause;
+import org.jenkinsci.plugins.buildtriggerbadge.provider.BuildTriggerBadgeDeactivator;
+
+@Extension
+public class NaginatorBuildTriggerBadgeDeactivator extends BuildTriggerBadgeDeactivator {
+
+    @Override
+    public boolean vetoBadge(Cause cause) {
+        return cause instanceof NaginatorCause;
+    }
+}

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorBuildTriggerBadgeDeactivator.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorBuildTriggerBadgeDeactivator.java
@@ -4,7 +4,7 @@ import hudson.Extension;
 import hudson.model.Cause;
 import org.jenkinsci.plugins.buildtriggerbadge.provider.BuildTriggerBadgeDeactivator;
 
-@Extension
+@Extension(optional = true)
 public class NaginatorBuildTriggerBadgeDeactivator extends BuildTriggerBadgeDeactivator {
 
     @Override

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorRetryAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorRetryAction.java
@@ -7,7 +7,10 @@ import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerResponse;

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/Messages.properties
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/Messages.properties
@@ -6,4 +6,5 @@ NoChildStrategy.RerunWhole.DisplayName=Rerun the matrix with all combinations
 NoChildStrategy.RerunEmpty.DisplayName=Rerun the matrix with no combinations
 NoChildStrategy.DontRerun.DisplayName=Don''t rerun
 NaginatorPublisher.RegexpForMatrixStrategy.RerunMatrixPartShouldBeEnabled=You need to enable "Rerun build only for failed parts on the matrix" to use this strategy.
+NaginatorAction.rescheduled=Re-scheduled after failure
 

--- a/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorAction/badge.jelly
+++ b/src/main/resources/com/chikli/hudson/plugin/naginator/NaginatorAction/badge.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <l:icon src="symbol-arrow-redo-outline plugin-ionicons-api" class="icon-sm" tooltip="${%Re-scheduled after failure}"/>
+    <l:icon src="symbol-arrow-redo-outline plugin-ionicons-api" class="icon-sm" tooltip="${it.tooltip}"/>
 </j:jelly>

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorCauseTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorCauseTest.java
@@ -45,8 +45,6 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
-import org.kohsuke.stapler.StaplerResponse;
-import org.mockito.Mock;
 
 /**
  * Tests for {@link NaginatorCause}
@@ -54,9 +52,6 @@ import org.mockito.Mock;
 public class NaginatorCauseTest {
     @ClassRule
     public static JenkinsRule j = new JenkinsRule();
-
-    @Mock
-    private StaplerResponse rsp;
 
 
     /**

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorCauseTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorCauseTest.java
@@ -203,33 +203,4 @@ public class NaginatorCauseTest {
             assertNull(unescaped);
         }
     }
-
-    @Issue("JENKINS-59222")
-    @Test
-    public void testRetryUserCause() throws Exception {
-        FreeStyleProject p = j.createFreeStyleProject();
-        p.getBuildersList().add(new FailureBuilder());
-        p.getPublishersList().add(new NaginatorPublisher(
-                "", // regexForRerun
-                true,       // rerunIfUnstable
-                false,      // rerunMatrixPart
-                false,      // checkRegexp
-                1,          // maxSchedule
-                new FixedDelay(0)   // delay
-        ));
-        p.scheduleBuild2(0);
-        j.waitUntilNoActivity();
-
-        assertEquals(2, p.getLastBuild().getNumber());
-
-        try (WebClient wc = j.createWebClient()) {
-            FreeStyleBuild b = p.getBuildByNumber(2);
-            NaginatorRetryAction.scheduleBuild2(b, 0,
-                    new NaginatorAction(b, NaginatorListener.calculateRetryCount(b), 0),
-                    true);
-            j.waitUntilNoActivity();
-            b = p.getBuildByNumber(3);
-            assertThat(b.getCauses(), hasItem(isA(Cause.UserIdCause.class)));
-        }
-    }
 }

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorListenerTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorListenerTest.java
@@ -132,9 +132,8 @@ public class NaginatorListenerTest extends HudsonTestCase {
         assertEquals(1, a.getLastBuild().getNumber());
         assertEquals(3, b.getLastBuild().getNumber());
         assertEquals(Result.FAILURE, b.getLastBuild().getResult());
-        assertEquals(2, b.getBuildByNumber(2).getActions(CauseAction.class).size());
-        assertEquals(2, b.getBuildByNumber(3).getActions(CauseAction.class).size());
-
+        assertEquals(2, b.getBuildByNumber(2).getAction(CauseAction.class).getCauses().size());
+        assertEquals(2, b.getBuildByNumber(3).getAction(CauseAction.class).getCauses().size());
     }
 
 
@@ -432,7 +431,7 @@ public class NaginatorListenerTest extends HudsonTestCase {
         }
     }
     
-    @Issue("JENKINS-34900")
+    @ Issue("JENKINS-34900")
     public void testMavenModuleSetWithoutNaginator() throws Exception {
         final String SIMPLE_POM = StringUtils.join(new String[]{
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorListenerTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorListenerTest.java
@@ -431,7 +431,7 @@ public class NaginatorListenerTest extends HudsonTestCase {
         }
     }
     
-    @ Issue("JENKINS-34900")
+    @Issue("JENKINS-34900")
     public void testMavenModuleSetWithoutNaginator() throws Exception {
         final String SIMPLE_POM = StringUtils.join(new String[]{
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorRetryActionTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorRetryActionTest.java
@@ -1,0 +1,86 @@
+package com.chikli.hudson.plugin.naginator;
+
+import hudson.model.Cause;
+import hudson.model.Cause.UserIdCause;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.User;
+import hudson.security.ACL;
+import hudson.security.ACLContext;
+import hudson.security.SecurityRealm;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.FailureBuilder;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class NaginatorRetryActionTest {
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+
+    private User user;
+
+    private FreeStyleProject project;
+    @Before
+    public void setup() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        user = User.getById("naginator", true);
+        project = j.createFreeStyleProject();
+        project.getBuildersList().add(new FailureBuilder());
+        project.getPublishersList().add(new NaginatorPublisher(
+                "", // regexForRerun
+                true,       // rerunIfUnstable
+                false,      // rerunMatrixPart
+                false,      // checkRegexp
+                2,          // maxSchedule
+                new FixedDelay(0)   // delay
+        ));
+        try (ACLContext ignored = ACL.as(user)) {
+            project.scheduleBuild2(0, new UserIdCause());
+        }
+        j.waitUntilNoActivity();
+    }
+
+    @Issue("JENKINS-59222")
+    @Test
+    public void testRetryUserCause() throws Exception {
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+            User retryUser = User.getById("retry", true);
+
+            FreeStyleBuild b = project.getBuildByNumber(3);
+            try (ACLContext ignored = ACL.as(retryUser)) {
+                NaginatorRetryAction.scheduleBuild2(b, 0,
+                        new NaginatorAction(b, NaginatorListener.calculateRetryCount(b), 0),
+                        true);
+            }
+            j.waitUntilNoActivity();
+            b = project.getBuildByNumber(4);
+            UserIdCause cause = b.getCause(UserIdCause.class);
+            assertThat(cause, is(notNullValue()));
+            assertThat(cause.getUserId(), is(retryUser.getId()));
+        }
+    }
+
+    @Test
+    public void testUserIsKept() {
+        FreeStyleBuild b = project.getBuildByNumber(3);
+        UserIdCause cause = b.getCause(UserIdCause.class);
+        assertThat(cause, is(notNullValue()));
+        assertThat(cause.getUserId(), is(user.getId()));
+    }
+
+    @Test
+    public void testNaginatorCauseAppearsOnlyOnce() {
+        FreeStyleBuild b = project.getBuildByNumber(3);
+        List<Cause> causes = b.getCauses();
+        long countOfNaginatorCause = causes.stream().filter(t -> t instanceof NaginatorCause).count();
+        assertThat(countOfNaginatorCause, is(1L));
+    }
+}


### PR DESCRIPTION
Adding a UserIdCause to the list of causes. Avoid creating a duplicate CauseAction. Filter out previous users and naginator causes to avoid lengthy cause lists.
The changed way of handling the cause requires to add a BuildTriggerBadgeDeactivator otherwise we will get 2 badges. Store the cause in the action so we can show the cause as tooltip (this includes the build number).

<!-- Please describe your pull request here. -->

### Testing done
Manual testing as well as adding an automated test

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
