### PR TITLE
Restore test scope to jenkins-test-harness-tools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,10 +114,11 @@
             <version>3.22</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-test-harness-tools</artifactId>
-            <version>2.2</version>
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-test-harness-tools</artifactId>
+      <version>2.2</version>
+      <scope>test</scope>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
The modernization PR (#58) dropped the test scope from this dependency.
This results in a lot of very old classes on the classpath for plugins that depend on this one.

Use this link to re-run the recipe: https://public.moderne.io/recipes/org.openrewrite.maven.ChangeDependencyScope?defaults=W3sibmFtZSI6Imdyb3VwSWQiLCJ2YWx1ZSI6Im9yZy5qZW5raW5zLWNpLm1haW4ifSx7Im5hbWUiOiJhcnRpZmFjdElkIiwidmFsdWUiOiJqZW5raW5zLXRlc3QtaGFybmVzcy10b29scyJ9LHsibmFtZSI6Im5ld1Njb3BlIiwidmFsdWUiOiJ0ZXN0In1d