### PR TITLE
Rebaseline Jenkins to 2.375.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.66</version>
+    <version>4.67</version>
   </parent>
   
   <name>Naginator</name>
@@ -26,7 +26,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.375.4</jenkins.version>
   </properties>
   
   <licenses>
@@ -75,8 +75,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.361.x</artifactId>
-        <version>2062.v154408a_24d20</version>
+        <artifactId>bom-2.375.x</artifactId>
+        <version>2179.v0884e842b_859</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
2.375.4 is now the lowest [recommended version](
https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#currently-recommended-versions)

Use this link to re-run the recipe: https://app.moderne.io/recipes/builder/4ZZ3Z