### PR TITLE
Internal: Migrate to JUnit4 and deprecated API cleanup

### DIFF
--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorActionFactoryTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorActionFactoryTest.java
@@ -152,7 +152,7 @@ public class NaginatorActionFactoryTest {
         FreeStyleProject p = r.createFreeStyleProject();
         p.getBuildersList().add(new FailureBuilder());
         FreeStyleBuild b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
-        assertRetryLinkExists(b, User.get("user1"));
+        assertRetryLinkExists(b, User.getOrCreateByIdOrFullName("user1"));
     }
     
     
@@ -167,7 +167,7 @@ public class NaginatorActionFactoryTest {
         FreeStyleProject p = r.createFreeStyleProject();
         p.getBuildersList().add(new FailureBuilder());
         FreeStyleBuild b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
-        assertRetryLinkNotExists(b, User.get("user1"));
+        assertRetryLinkNotExists(b, User.getOrCreateByIdOrFullName("user1"));
     }
     
     @Test
@@ -186,6 +186,6 @@ public class NaginatorActionFactoryTest {
         
         p.getBuildersList().add(new FailureBuilder());
         FreeStyleBuild b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
-        assertRetryLinkExists(b, User.get("user1"));
+        assertRetryLinkExists(b, User.getOrCreateByIdOrFullName("user1"));
     }
 }

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorActionFactoryTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorActionFactoryTest.java
@@ -84,19 +84,27 @@ public class NaginatorActionFactoryTest {
     }
     
     private void assertRetryLinkExists(AbstractBuild<?, ?> b) throws Exception {
-        assertRetryLinkExists(b, r.createWebClient());
+        try (WebClient webClient = r.createWebClient()) {
+            assertRetryLinkExists(b, webClient);
+        }
     }
     
     private void assertRetryLinkNotExists(AbstractBuild<?, ?> b) throws Exception {
-        assertRetryLinkNotExists(b, r.createWebClient());
+        try (WebClient webClient = r.createWebClient()) {
+            assertRetryLinkNotExists(b, webClient);
+        }
     }
     
     private void assertRetryLinkExists(AbstractBuild<?, ?> b, User u) throws Exception {
-        assertRetryLinkExists(b, r.createWebClient().login(u.getId()));
+        try (WebClient webClient = r.createWebClient()) {
+            assertRetryLinkExists(b, webClient.login(u.getId()));
+        }
     }
     
     private void assertRetryLinkNotExists(AbstractBuild<?, ?> b, User u) throws Exception {
-        assertRetryLinkNotExists(b, r.createWebClient().login(u.getId()));
+        try (WebClient webClient = r.createWebClient()) {
+            assertRetryLinkNotExists(b, webClient.login(u.getId()));
+        }
     }
     
     @Test

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorActionFactoryTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorActionFactoryTest.java
@@ -67,7 +67,7 @@ public class NaginatorActionFactoryTest {
         r.jenkins.setAuthorizationStrategy(null);
     }
     
-    private String getRetryLinkFor(AbstractBuild<?, ?> b) throws Exception {
+    private String getRetryLinkFor(AbstractBuild<?, ?> b) {
         return Functions.joinPath(r.contextPath, b.getUrl(), "retry");
     }
     

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorActionFactoryTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorActionFactoryTest.java
@@ -24,34 +24,34 @@
 
 package com.chikli.hudson.plugin.naginator;
 
-import static org.junit.Assert.fail;
+import com.google.common.collect.Sets;
+import hudson.Functions;
+import hudson.model.AbstractBuild;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Item;
+import hudson.model.Result;
+import hudson.model.User;
+import hudson.security.AuthorizationMatrixProperty;
+import hudson.security.Permission;
+import hudson.security.ProjectMatrixAuthorizationStrategy;
+import jenkins.model.Jenkins;
+import org.htmlunit.ElementNotFoundException;
+import org.htmlunit.html.HtmlAnchor;
+import org.jenkinsci.plugins.matrixauth.PermissionEntry;
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.FailureBuilder;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import jenkins.model.Jenkins;
-import hudson.Functions;
-import hudson.model.FreeStyleBuild;
-import hudson.model.Item;
-import hudson.model.Result;
-import hudson.model.AbstractBuild;
-import hudson.model.FreeStyleProject;
-import hudson.model.User;
-import hudson.security.Permission;
-import hudson.security.AuthorizationMatrixProperty;
-import hudson.security.ProjectMatrixAuthorizationStrategy;
-
-import org.junit.After;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.JenkinsRule.WebClient;
-import org.jvnet.hudson.test.FailureBuilder;
-
-import org.htmlunit.ElementNotFoundException;
-import org.htmlunit.html.HtmlAnchor;
-import com.google.common.collect.Sets;
+import static org.jenkinsci.plugins.matrixauth.AuthorizationType.EITHER;
+import static org.junit.Assert.fail;
 
 /**
  *
@@ -144,9 +144,9 @@ public class NaginatorActionFactoryTest {
     public void testRetryLinkForPermittedUser() throws Exception {
         r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
         ProjectMatrixAuthorizationStrategy pmas = new ProjectMatrixAuthorizationStrategy();
-        pmas.add(Jenkins.READ, "user1");
-        pmas.add(Item.READ, "user1");
-        pmas.add(Item.BUILD, "user1");
+        pmas.add(Jenkins.READ, new PermissionEntry(EITHER, "user1"));
+        pmas.add(Item.READ, new PermissionEntry(EITHER, "user1"));
+        pmas.add(Item.BUILD, new PermissionEntry(EITHER, "user1"));
         r.jenkins.setAuthorizationStrategy(pmas);
         
         FreeStyleProject p = r.createFreeStyleProject();
@@ -160,9 +160,8 @@ public class NaginatorActionFactoryTest {
     public void testRetryLinkNotForNonPermittedUser() throws Exception {
         r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
         ProjectMatrixAuthorizationStrategy pmas = new ProjectMatrixAuthorizationStrategy();
-        pmas.add(Jenkins.READ, "user1");
-        pmas.add(Item.READ, "user1");
-        //pmas.add(Item.BUILD, "user1");
+        pmas.add(Jenkins.READ, new PermissionEntry(EITHER, "user1"));
+        pmas.add(Item.READ, new PermissionEntry(EITHER, "user1"));
         r.jenkins.setAuthorizationStrategy(pmas);
         
         FreeStyleProject p = r.createFreeStyleProject();
@@ -175,7 +174,7 @@ public class NaginatorActionFactoryTest {
     public void testRetryLinkForPermittedUserByProject() throws Exception {
         r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
         ProjectMatrixAuthorizationStrategy pmas = new ProjectMatrixAuthorizationStrategy();
-        pmas.add(Jenkins.READ, "user1");
+        pmas.add(Jenkins.READ, new PermissionEntry(EITHER, "user1"));
         r.jenkins.setAuthorizationStrategy(pmas);
         
         FreeStyleProject p = r.createFreeStyleProject();

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorActionFactoryTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorActionFactoryTest.java
@@ -39,6 +39,7 @@ import jenkins.model.Jenkins;
 import org.htmlunit.ElementNotFoundException;
 import org.htmlunit.html.HtmlAnchor;
 import org.jenkinsci.plugins.matrixauth.PermissionEntry;
+import org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy;
 import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -179,10 +180,10 @@ public class NaginatorActionFactoryTest {
         
         FreeStyleProject p = r.createFreeStyleProject();
         
-        Map<Permission, Set<String>> authMap = new HashMap<Permission, Set<String>>();
-        authMap.put(Item.READ, Sets.newHashSet("user1"));
-        authMap.put(Item.BUILD, Sets.newHashSet("user1"));
-        p.addProperty(new AuthorizationMatrixProperty(authMap));
+        Map<Permission, Set<PermissionEntry>> authMap = new HashMap<>();
+        authMap.put(Item.READ, Sets.newHashSet(new PermissionEntry(EITHER, "user1")));
+        authMap.put(Item.BUILD, Sets.newHashSet(new PermissionEntry(EITHER, "user1")));
+        p.addProperty(new AuthorizationMatrixProperty(authMap, new InheritParentStrategy()));
         
         p.getBuildersList().add(new FailureBuilder());
         FreeStyleBuild b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorCauseTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorCauseTest.java
@@ -24,10 +24,11 @@
 
 package com.chikli.hudson.plugin.naginator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import org.htmlunit.html.DomElement;
+import org.htmlunit.html.HtmlAnchor;
+import org.htmlunit.html.HtmlPage;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.FailureBuilder;
@@ -35,12 +36,10 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 
-import org.htmlunit.html.DomElement;
-import org.htmlunit.html.HtmlAnchor;
-import org.htmlunit.html.HtmlPage;
-
-import hudson.model.FreeStyleBuild;
-import hudson.model.FreeStyleProject;
+import static com.chikli.hudson.plugin.naginator.testutils.TestSupport.lastBuildNumber;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests for {@link NaginatorCause}
@@ -72,7 +71,7 @@ public class NaginatorCauseTest {
         p.scheduleBuild2(0);
         j.waitUntilNoActivity();
 
-        assertEquals(3, p.getLastBuild().getNumber());
+        assertEquals(3, lastBuildNumber(p));
 
         try (WebClient wc = j.createWebClient()) {
             {
@@ -115,7 +114,7 @@ public class NaginatorCauseTest {
         p.scheduleBuild2(0);
         j.waitUntilNoActivity();
 
-        assertEquals(3, p.getLastBuild().getNumber());
+        assertEquals(3, lastBuildNumber(p));
 
         p.getBuildByNumber(1).delete();
 
@@ -157,7 +156,7 @@ public class NaginatorCauseTest {
         p.scheduleBuild2(0);
         j.waitUntilNoActivity();
 
-        assertEquals(2002, p.getLastBuild().getNumber());
+        assertEquals(2002, lastBuildNumber(p));
 
         try (WebClient wc = j.createWebClient()) {
             {

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorListenerTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorListenerTest.java
@@ -47,12 +47,15 @@ import org.jvnet.hudson.test.ToolInstallations;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class NaginatorListenerTest {
     @ClassRule
@@ -60,47 +63,47 @@ public class NaginatorListenerTest {
 
     @Test
     public void testSuccessNoRebuild() throws Exception {
-        assertEquals(false, isScheduledForRetry("build log", Result.SUCCESS, "foo", false, false));
+        assertFalse(isScheduledForRetry("build log", Result.SUCCESS, "foo", false, false));
     }
 
     @Test
     public void testUnstableNoRebuild() throws Exception {
-        assertEquals(false, isScheduledForRetry("build log", Result.SUCCESS, "foo", false, false));
+        assertFalse(isScheduledForRetry("build log", Result.SUCCESS, "foo", false, false));
     }
 
     @Test
     public void testUnstableWithRebuild() throws Exception {
-        assertEquals(true, isScheduledForRetry("build log", Result.UNSTABLE, "foo", true, false));
+        assertTrue(isScheduledForRetry("build log", Result.UNSTABLE, "foo", true, false));
     }
 
     @Test
     public void testFailureWithRebuild() throws Exception {
-        assertEquals(true, isScheduledForRetry("build log", Result.FAILURE, "foo", false, false));
+        assertTrue(isScheduledForRetry("build log", Result.FAILURE, "foo", false, false));
     }
 
     @Test
     public void testFailureWithUnstableRebuild() throws Exception {
-        assertEquals(true, isScheduledForRetry("build log", Result.FAILURE, "foo", true, false));
+        assertTrue(isScheduledForRetry("build log", Result.FAILURE, "foo", true, false));
     }
 
     @Test
     public void testFailureWithoutRebuildRegexp() throws Exception {
-        assertEquals(false, isScheduledForRetry("build log", Result.FAILURE, "foo", false, true));
+        assertFalse(isScheduledForRetry("build log", Result.FAILURE, "foo", false, true));
     }
 
     @Test
     public void testFailureWithRebuildRegexp() throws Exception {
-        assertEquals(true, isScheduledForRetry("build log foo", Result.FAILURE, "foo", false, true));
+        assertTrue(isScheduledForRetry("build log foo", Result.FAILURE, "foo", false, true));
     }
 
     @Test
     public void testUnstableWithoutRebuildRegexp() throws Exception {
-        assertEquals(false, isScheduledForRetry("build log", Result.UNSTABLE, "foo", true, true));
+        assertFalse(isScheduledForRetry("build log", Result.UNSTABLE, "foo", true, true));
     }
 
     @Test
     public void testUnstableWithRebuildRegexp() throws Exception {
-        assertEquals(true, isScheduledForRetry("build log foo", Result.UNSTABLE, "foo", true, true));
+        assertTrue(isScheduledForRetry("build log foo", Result.UNSTABLE, "foo", true, true));
     }
 
     @Test
@@ -113,7 +116,7 @@ public class NaginatorListenerTest {
         BuildWrapper failTheBuild = new FailTheBuild();
         project.getBuildWrappersList().add(failTheBuild);
 
-        assertEquals(true, isScheduledForRetry(project));
+        assertTrue(isScheduledForRetry(project));
     }
 
     /**
@@ -481,7 +484,7 @@ public class NaginatorListenerTest {
         // as SingleFileSCM in jenkins-test-harness doesn't work with
         // Jenkins 1.554, use a simple custom JobProperty instead.
         // p.setScm(new SingleFileSCM("pom.xml", SIMPLE_POM));
-        p.addProperty(new PrepareSingleFileProperty("pom.xml", SIMPLE_POM.getBytes("UTF-8")));
+        p.addProperty(new PrepareSingleFileProperty("pom.xml", SIMPLE_POM.getBytes(StandardCharsets.UTF_8)));
         p.setGoals("clean");
         
         // Run once to have the project read the module structure.

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorPublisherTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorPublisherTest.java
@@ -24,30 +24,31 @@
 
 package com.chikli.hudson.plugin.naginator;
 
-import static org.junit.Assert.*;
-
-import java.io.IOException;
-import java.lang.reflect.Field;
-
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
-
 import com.chikli.hudson.plugin.naginator.testutils.MyBuilder;
-
 import hudson.AbortException;
 import hudson.Launcher;
 import hudson.matrix.Axis;
 import hudson.matrix.AxisList;
 import hudson.matrix.Combination;
-import hudson.matrix.MatrixRun;
 import hudson.matrix.MatrixBuild;
 import hudson.matrix.MatrixProject;
+import hudson.matrix.MatrixRun;
 import hudson.model.AbstractBuild;
-import hudson.model.FreeStyleProject;
 import hudson.model.BuildListener;
+import hudson.model.FreeStyleProject;
 import hudson.model.Result;
 import hudson.tasks.Builder;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+import static com.chikli.hudson.plugin.naginator.testutils.TestSupport.lastBuildNumber;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests for {@link NaginatorPublisher}.
@@ -113,10 +114,11 @@ public class NaginatorPublisherTest {
         p.scheduleBuild2(0);
         j.waitUntilNoActivity();
         
-        assertEquals(maxSchedule + 1, p.getLastBuild().number);
+        assertEquals(maxSchedule + 1, lastBuildNumber(p));
         
         // (1, 1), (1, 2), (2, 1), (2, 2) are rescheduled.
         MatrixBuild b = p.getLastBuild();
+        assertNotNull(b);
         assertNotNull(b.getExactRun(new Combination(axes, "1", "1")));
         assertNotNull(b.getExactRun(new Combination(axes, "1", "2")));
         assertNotNull(b.getExactRun(new Combination(axes, "2", "1")));
@@ -152,10 +154,11 @@ public class NaginatorPublisherTest {
         p.scheduleBuild2(0);
         j.waitUntilNoActivity();
         
-        assertEquals(maxSchedule + 1, p.getLastBuild().number);
+        assertEquals(maxSchedule + 1, lastBuildNumber(p));
         
         // (1, 2), (2, 1) are rescheduled.
         MatrixBuild b = p.getLastBuild();
+        assertNotNull(b);
         assertNull(b.getExactRun(new Combination(axes, "1", "1")));
         assertNotNull(b.getExactRun(new Combination(axes, "1", "2")));
         assertNotNull(b.getExactRun(new Combination(axes, "2", "1")));
@@ -193,7 +196,7 @@ public class NaginatorPublisherTest {
         j.waitUntilNoActivity();
         
         // build rescheduled.
-        assertEquals(2, p.getLastBuild().number);
+        assertEquals(2, lastBuildNumber(p));
     }
     
     /**
@@ -227,7 +230,7 @@ public class NaginatorPublisherTest {
         j.waitUntilNoActivity();
         
         // build rescheduled.
-        assertEquals(1, p.getLastBuild().number);
+        assertEquals(1, lastBuildNumber(p));
     }
     
     
@@ -261,10 +264,11 @@ public class NaginatorPublisherTest {
         j.waitUntilNoActivity();
         
         // build rescheduled.
-        assertEquals(2, p.getLastBuild().number);
+        assertEquals(2, lastBuildNumber(p));
         
         // only axis1=value1, axis1=value3 is rescheduled for the regular expression.
         MatrixBuild b = p.getLastBuild();
+        assertNotNull(b);
         assertNotNull(b.getExactRun(new Combination(axes, "value1")));
         assertNull(b.getExactRun(new Combination(axes, "value2")));
         assertNotNull(b.getExactRun(new Combination(axes, "value3")));
@@ -303,7 +307,7 @@ public class NaginatorPublisherTest {
         
         // build is rescheduled
         // as regular expression is not applied actually.
-        assertEquals(2, p.getLastBuild().number);
+        assertEquals(2, lastBuildNumber(p));
     }
     
     /**
@@ -336,10 +340,11 @@ public class NaginatorPublisherTest {
         j.waitUntilNoActivity();
         
         // build rescheduled.
-        assertEquals(2, p.getLastBuild().number);
+        assertEquals(2, lastBuildNumber(p));
         
         // only axis1=value1, axis1=value3 is rescheduled for the failure.
         MatrixBuild b = p.getLastBuild();
+        assertNotNull(b);
         assertNotNull(b.getExactRun(new Combination(axes, "value1")));
         assertNull(b.getExactRun(new Combination(axes, "value2")));
         assertNotNull(b.getExactRun(new Combination(axes, "value3")));
@@ -376,10 +381,11 @@ public class NaginatorPublisherTest {
         j.waitUntilNoActivity();
         
         // build rescheduled.
-        assertEquals(2, p.getLastBuild().number);
+        assertEquals(2, lastBuildNumber(p));
         
         // all axes are rescheduled
         MatrixBuild b = p.getLastBuild();
+        assertNotNull(b);
         assertNotNull(b.getExactRun(new Combination(axes, "value1")));
         assertNotNull(b.getExactRun(new Combination(axes, "value2")));
         assertNotNull(b.getExactRun(new Combination(axes, "value3")));
@@ -416,7 +422,7 @@ public class NaginatorPublisherTest {
         j.waitUntilNoActivity();
         
         // build is not rescheduled as no child matches the regexp.
-        assertEquals(1, p.getLastBuild().number);
+        assertEquals(1, lastBuildNumber(p));
     }
     
     /**
@@ -493,6 +499,7 @@ public class NaginatorPublisherTest {
     @Test
     public void testRegexpTimeoutMsInSystemConfiguration() throws Exception {
         NaginatorPublisher.DescriptorImpl d = (NaginatorPublisher.DescriptorImpl)j.jenkins.getDescriptor(NaginatorPublisher.class);
+        assertNotNull(d);
         d.setRegexpTimeoutMs(NaginatorPublisher.DEFAULT_REGEXP_TIMEOUT_MS);
         d.save();       // ensure the default value is saved to the file.
         

--- a/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorScheduleActionTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/NaginatorScheduleActionTest.java
@@ -24,29 +24,33 @@
 
 package com.chikli.hudson.plugin.naginator;
 
-import static org.junit.Assert.*;
-
-import java.io.IOException;
-
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Launcher;
 import hudson.matrix.Axis;
 import hudson.matrix.AxisList;
 import hudson.matrix.Combination;
-import hudson.matrix.MatrixRun;
 import hudson.matrix.MatrixBuild;
 import hudson.matrix.MatrixProject;
+import hudson.matrix.MatrixRun;
 import hudson.model.AbstractBuild;
-import hudson.model.FreeStyleProject;
 import hudson.model.BuildListener;
 import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.Builder;
-
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+
+import static com.chikli.hudson.plugin.naginator.testutils.TestSupport.lastBuildNumber;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  *
@@ -189,7 +193,7 @@ public class NaginatorScheduleActionTest {
         j.waitUntilNoActivity();
         
         // no reschedule.
-        assertEquals(1, p.getLastBuild().number);
+        assertEquals(1, lastBuildNumber(p));
     }
     
     /**
@@ -214,7 +218,7 @@ public class NaginatorScheduleActionTest {
         p.scheduleBuild2(0);
         j.waitUntilNoActivity();
         
-        assertEquals(maxSchedule + 1, p.getLastBuild().number);
+        assertEquals(maxSchedule + 1, lastBuildNumber(p));
     }
         
     /**
@@ -238,7 +242,7 @@ public class NaginatorScheduleActionTest {
         j.waitUntilNoActivity();
         
         // no reschedule.
-        assertEquals(1, p.getLastBuild().number);
+        assertEquals(1, lastBuildNumber(p));
     }
         
     /**
@@ -268,7 +272,7 @@ public class NaginatorScheduleActionTest {
         p.scheduleBuild2(0);
         j.waitUntilNoActivity();
         
-        assertEquals(maxSchedule + 1, p.getLastBuild().number);
+        assertEquals(maxSchedule + 1, lastBuildNumber(p));
     }
     
     /**
@@ -299,10 +303,11 @@ public class NaginatorScheduleActionTest {
         p.scheduleBuild2(0);
         j.waitUntilNoActivity();
         
-        assertEquals(maxSchedule + 1, p.getLastBuild().number);
+        assertEquals(maxSchedule + 1, lastBuildNumber(p));
         
         // (1, 1), (1, 2), (2, 1) are scheduled
         MatrixBuild b = p.getLastBuild();
+        assertNotNull(b);
         assertNotNull(b.getExactRun(new Combination(axes, "1", "1")));
         assertNotNull(b.getExactRun(new Combination(axes, "1", "2")));
         assertNotNull(b.getExactRun(new Combination(axes, "2", "1")));
@@ -337,10 +342,11 @@ public class NaginatorScheduleActionTest {
         p.scheduleBuild2(0);
         j.waitUntilNoActivity();
         
-        assertEquals(maxSchedule + 1, p.getLastBuild().number);
+        assertEquals(maxSchedule + 1, lastBuildNumber(p));
         
         // (1, 2), (2, 1) are scheduled
         MatrixBuild b = p.getLastBuild();
+        assertNotNull(b);
         assertNull(b.getExactRun(new Combination(axes, "1", "1")));
         assertNotNull(b.getExactRun(new Combination(axes, "1", "2")));
         assertNotNull(b.getExactRun(new Combination(axes, "2", "1")));
@@ -375,10 +381,11 @@ public class NaginatorScheduleActionTest {
         p.scheduleBuild2(0);
         j.waitUntilNoActivity();
         
-        assertEquals(maxSchedule + 1, p.getLastBuild().number);
+        assertEquals(maxSchedule + 1, lastBuildNumber(p));
         
         // (1, 1), (1, 2), (2, 1) are scheduled
         MatrixBuild b = p.getLastBuild();
+        assertNotNull(b);
         assertNotNull(b.getExactRun(new Combination(axes, "1", "1")));
         assertNotNull(b.getExactRun(new Combination(axes, "1", "2")));
         assertNotNull(b.getExactRun(new Combination(axes, "2", "1")));
@@ -414,7 +421,7 @@ public class NaginatorScheduleActionTest {
         p.scheduleBuild2(0);
         j.waitUntilNoActivity();
         
-        assertEquals(1, p.getLastBuild().number);
+        assertEquals(1, lastBuildNumber(p));
     }
     
     /**
@@ -446,10 +453,11 @@ public class NaginatorScheduleActionTest {
         p.scheduleBuild2(0);
         j.waitUntilNoActivity();
         
-        assertEquals(maxSchedule + 1, p.getLastBuild().number);
+        assertEquals(maxSchedule + 1, lastBuildNumber(p));
         
         // No children are rescheduled
         MatrixBuild b = p.getLastBuild();
+        assertNotNull(b);
         assertNull(b.getExactRun(new Combination(axes, "1", "1")));
         assertNull(b.getExactRun(new Combination(axes, "1", "2")));
         assertNull(b.getExactRun(new Combination(axes, "2", "1")));
@@ -484,10 +492,11 @@ public class NaginatorScheduleActionTest {
         p.scheduleBuild2(0);
         j.waitUntilNoActivity();
         
-        assertEquals(maxSchedule + 1, p.getLastBuild().number);
+        assertEquals(maxSchedule + 1, lastBuildNumber(p));
         
         // (1, 1), (1, 2), (2, 1) are scheduled
         MatrixBuild b = p.getLastBuild();
+        assertNotNull(b);
         assertNotNull(b.getExactRun(new Combination(axes, "1", "1")));
         assertNotNull(b.getExactRun(new Combination(axes, "1", "2")));
         assertNotNull(b.getExactRun(new Combination(axes, "2", "1")));

--- a/src/test/java/com/chikli/hudson/plugin/naginator/ProgressiveDelayTest.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/ProgressiveDelayTest.java
@@ -1,21 +1,18 @@
 package com.chikli.hudson.plugin.naginator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.util.Arrays;
-
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.FailureBuilder;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import hudson.model.AbstractBuild;
-import hudson.model.FreeStyleBuild;
-import hudson.model.FreeStyleProject;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * A test suite for {@link ProgressiveDelay}.
@@ -41,6 +38,7 @@ public class ProgressiveDelayTest {
 
         FreeStyleBuild build1 = p.getFirstBuild();
         FreeStyleBuild build2 = build1.getNextBuild();
+        assertNotNull(build2);
         FreeStyleBuild build3 = build2.getNextBuild();
 
         final ProgressiveDelay progressiveDelay = new ProgressiveDelay(15, 50);
@@ -73,6 +71,7 @@ public class ProgressiveDelayTest {
 
         FreeStyleBuild build1 = p.getFirstBuild();
         FreeStyleBuild build2 = build1.getNextBuild();
+        assertNotNull(build2);
         FreeStyleBuild build3 = build2.getNextBuild();
 
         final ProgressiveDelay progressiveDelay = new ProgressiveDelay(15, 0);
@@ -128,12 +127,5 @@ public class ProgressiveDelayTest {
                 delay.computeScheduleDelay(buildA3)
             )
         );
-    }
-
-    private static AbstractBuild createBuild(final boolean hasNaginatorAction, final AbstractBuild previousBuild) {
-        final AbstractBuild build = mock(AbstractBuild.class);
-        when(build.getPreviousBuild()).thenReturn(previousBuild);
-        when(build.getAction(NaginatorAction.class)).thenReturn(hasNaginatorAction ? new NaginatorAction(0) : null);
-        return build;
     }
 }

--- a/src/test/java/com/chikli/hudson/plugin/naginator/testutils/TestSupport.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/testutils/TestSupport.java
@@ -1,0 +1,20 @@
+package com.chikli.hudson.plugin.naginator.testutils;
+
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+
+public class TestSupport {
+    private TestSupport() {
+    }
+
+    public static int lastBuildNumber(AbstractProject<?, ?> p) {
+        if (p == null) {
+            return -2;
+        }
+        AbstractBuild<?, ?> b = p.getLastBuild();
+        if (b == null) {
+            return -1;
+        }
+        return b.getNumber();
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This change updates `NaginatorListenerTest` from `HudsonTestCase` (JUnit3) to JUnit4. It also simplifies assertions and fixes various warnings in IntelliJ for:

* Using webclient outside of try-with-resources
* Using deprecated APIs in Jenkins from tests
* Possible NullPointerExceptions, by introducing the `TestSupport#lastBuildNumber` method and adding `assertNotNull` in places


### Testing done

None of the main sources were changed, existing tests continue to pass.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
