### PR TITLE
Migrate from EE 8 to EE 9

### DIFF
--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisher.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorPublisher.java
@@ -19,7 +19,7 @@ import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
@@ -262,10 +262,10 @@ public class NaginatorPublisher extends Notifier {
         }
 
         /**
-         * @see hudson.model.Descriptor#configure(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObject)
+         * @see hudson.model.Descriptor#configure(org.kohsuke.stapler.StaplerRequest2, net.sf.json.JSONObject)
          */
         @Override
-        public boolean configure(StaplerRequest req, JSONObject json) throws hudson.model.Descriptor.FormException {
+        public boolean configure(StaplerRequest2 req, JSONObject json) throws hudson.model.Descriptor.FormException {
             setRegexpTimeoutMs(json.getLong("regexpTimeoutMs"));
             boolean result = super.configure(req, json);
             save();

--- a/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorRetryAction.java
+++ b/src/main/java/com/chikli/hudson/plugin/naginator/NaginatorRetryAction.java
@@ -5,12 +5,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import hudson.model.Cause;
@@ -27,7 +27,7 @@ import hudson.model.Run;
 public class NaginatorRetryAction implements Action {
 
     private boolean hasPermission() {
-        Run<?, ?> run = Stapler.getCurrentRequest().findAncestorObject(Run.class);
+        Run<?, ?> run = Stapler.getCurrentRequest2().findAncestorObject(Run.class);
         if (run == null) {
             // this page should be shown only when
             // there's a valid build in the path hierarchy.
@@ -60,7 +60,7 @@ public class NaginatorRetryAction implements Action {
     }
 
     @RequirePOST
-    public void doIndex(StaplerResponse res, @CheckForNull @AncestorInPath AbstractBuild<?, ?> build) throws IOException {
+    public void doIndex(StaplerResponse2 res, @CheckForNull @AncestorInPath AbstractBuild<?, ?> build) throws IOException {
         if (build == null) {
             // This should not happen as
             // this page is displayed only for AbstractBuild.

--- a/src/test/java/com/chikli/hudson/plugin/naginator/testutils/MyBuilder.java
+++ b/src/test/java/com/chikli/hudson/plugin/naginator/testutils/MyBuilder.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 
 import net.sf.json.JSONObject;
 
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 public final class MyBuilder extends Builder {
     private final String text;
@@ -66,7 +66,7 @@ public final class MyBuilder extends Builder {
         public String getDisplayName() {
             return "MyBuilder";
         }
-        public MyBuilder newInstance(StaplerRequest req, JSONObject data) {
+        public MyBuilder newInstance(StaplerRequest2 req, JSONObject data) {
             return new MyBuilder("foo", Result.SUCCESS);
         }
     }


### PR DESCRIPTION
Migrate from deprecated EE 8 methods to non-deprecated EE 9 equivalents.